### PR TITLE
Adapted to work with upstream changes in taskcluster-client-go

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -313,7 +313,7 @@ func (task *TaskRun) uploadArtifact(artifact Artifact) error {
 		return err
 	}
 	par := queue.PostArtifactRequest(json.RawMessage(payload))
-	parsp, callSummary, err := Queue.CreateArtifact(
+	parsp, err := Queue.CreateArtifact(
 		task.TaskId,
 		strconv.Itoa(int(task.RunId)),
 		artifact.Base().CanonicalPath,
@@ -321,22 +321,9 @@ func (task *TaskRun) uploadArtifact(artifact Artifact) error {
 	)
 	if err != nil {
 		log.Printf("Could not upload artifact: %v", artifact)
-		log.Printf("%v", callSummary)
 		log.Printf("%v", parsp)
-		log.Println("Request Headers")
-		callSummary.HttpRequest.Header.Write(os.Stdout)
-		log.Println("Request Body")
-		log.Println(callSummary.HttpRequestBody)
-		log.Println("Response Headers")
-		callSummary.HttpResponse.Header.Write(os.Stdout)
-		log.Println("Response Body")
-		log.Println(callSummary.HttpResponseBody)
 		return err
 	}
-	log.Println("Response body RAW")
-	log.Println(callSummary.HttpResponseBody)
-	log.Println("Response body INTERPRETED")
-	log.Println(string(*parsp))
 	// unmarshal response into object
 	resp := artifact.ResponseObject()
 	err = json.Unmarshal(json.RawMessage(*parsp), resp)

--- a/aws.go
+++ b/aws.go
@@ -192,9 +192,9 @@ func (c *Config) updateConfigWithAmazonSettings() error {
 		Authenticate: false,
 		BaseURL:      userData.ProvisionerBaseUrl,
 	}
-	secToken, _, getErr := awsprov.GetSecret(userData.SecurityToken)
+	secToken, getErr := awsprov.GetSecret(userData.SecurityToken)
 	// remove secrets even if we couldn't retrieve them!
-	_, removeErr := awsprov.RemoveSecret(userData.SecurityToken)
+	removeErr := awsprov.RemoveSecret(userData.SecurityToken)
 	if getErr != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -322,7 +322,7 @@ func runWorker() chan<- bool {
 		// Queue is the object we will use for accessing queue api
 		Queue = queue.New(
 			&tcclient.Credentials{
-				ClientId:    config.ClientId,
+				ClientID:    config.ClientId,
 				AccessToken: config.AccessToken,
 				Certificate: config.Certificate,
 			},

--- a/model.go
+++ b/model.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/xml"
 	"fmt"
 	"net"
@@ -9,7 +8,6 @@ import (
 
 	"github.com/taskcluster/generic-worker/livelog"
 	"github.com/taskcluster/taskcluster-client-go/queue"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
 type ExecCommand interface {
@@ -64,7 +62,6 @@ type (
 		RunId               uint                         `json:"runId"`
 		QueueMessage        QueueMessage                 `json:"-"`
 		SignedURLPair       SignedURLPair                `json:"-"`
-		ClaimCallSummary    tcclient.CallSummary         `json:"-"`
 		TaskClaimRequest    queue.TaskClaimRequest       `json:"-"`
 		TaskClaimResponse   queue.TaskClaimResponse      `json:"-"`
 		TaskReclaimResponse queue.TaskReclaimResponse    `json:"-"`
@@ -129,22 +126,6 @@ func (c *azureTimeFormat) UnmarshalXML(d *xml.Decoder, start xml.StartElement) e
 func (task *TaskRun) String() string {
 	response := fmt.Sprintf("Task Id:                 %v\n", task.TaskId)
 	response += fmt.Sprintf("Run Id:                  %v\n", task.RunId)
-	response += fmt.Sprintf("==========================================\n")
-	response += fmt.Sprintf("Claim URL:               %v\n", task.ClaimCallSummary.HttpRequest.URL.String())
-	response += fmt.Sprintf("Claim Method:            %v\n", task.ClaimCallSummary.HttpRequest.Method)
-	response += fmt.Sprintf("Claim Request Headers:\n")
-	buffer := new(bytes.Buffer)
-	task.ClaimCallSummary.HttpRequest.Header.Write(buffer)
-	response += buffer.String()
-	response += fmt.Sprintf("Claim Request Body:      %v\n", task.ClaimCallSummary.HttpRequestBody)
-	response += fmt.Sprintf("==========================================\n")
-	response += fmt.Sprintf("Claim Response Headers:\n")
-	buffer = new(bytes.Buffer)
-	task.ClaimCallSummary.HttpResponse.Header.Write(buffer)
-	response += buffer.String()
-	response += fmt.Sprintf("Claim Response Body:     %v\n", task.ClaimCallSummary.HttpResponseBody)
-	response += fmt.Sprintf("Claim Response Code:     %v\n", task.ClaimCallSummary.HttpResponse.StatusCode)
-	response += fmt.Sprintf("==========================================\n")
 	response += fmt.Sprintf("Run Id (Task Claim):     %v\n", task.TaskClaimResponse.RunID)
 	response += fmt.Sprintf("Message Id:              %v\n", task.QueueMessage.MessageId)
 	response += fmt.Sprintf("Insertion Time:          %v\n", task.QueueMessage.InsertionTime)

--- a/show-workers/main.go
+++ b/show-workers/main.go
@@ -20,24 +20,24 @@ import (
 
 func main() {
 	tcCreds := &tcclient.Credentials{
-		ClientId:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
+		ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
 		AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
 		Certificate: os.Getenv("TASKCLUSTER_CERTIFICATE"),
 	}
 	mySecrets := secrets.New(tcCreds)
-	s, _, err := mySecrets.List()
+	s, err := mySecrets.List()
 	if err != nil {
 		log.Fatalf("Could not read secrets: '%v'", err)
 	}
 	if len(s.Secrets) == 0 {
-		log.Fatalf("Taskcluster secrets service returned zero secrets, but auth did not fail, so it seems your client (%v) does not have scopes\nfor getting existing secrets (recommended: \"secrets:get:project/taskcluster/aws-provisioner-v1/worker-types/ssh-keys/*\")", tcCreds.ClientId)
+		log.Fatalf("Taskcluster secrets service returned zero secrets, but auth did not fail, so it seems your client (%v) does not have scopes\nfor getting existing secrets (recommended: \"secrets:get:project/taskcluster/aws-provisioner-v1/worker-types/ssh-keys/*\")", tcCreds.ClientID)
 	}
 	for _, name := range s.Secrets {
 		if strings.HasPrefix(name, "project/taskcluster/aws-provisioner-v1/worker-types/ssh-keys/") {
 			workerType := name[61:]
 			fmt.Printf("\nWorker type: %v\n", workerType)
 			fmt.Println(strings.Repeat("=", len(workerType)+13))
-			secret, _, err := mySecrets.Get(name)
+			secret, err := mySecrets.Get(name)
 			if err != nil {
 				log.Fatalf("Could not read secret %v: '%v'", name, err)
 			}

--- a/signedurlmanager.go
+++ b/signedurlmanager.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/taskcluster/taskcluster-client-go/queue"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
 // This function is called in a dedicated go routine to both serve signed urls
@@ -20,7 +19,6 @@ func SignedURLsManager() (chan chan *queue.PollTaskUrlsResponse, chan *queue.Pol
 	prematurity := config.RefreshUrlsPrematurelySecs
 	// signedURLs is the variable where we store the current valid signed urls
 	var signedURLs *queue.PollTaskUrlsResponse
-	var callSummary *tcclient.CallSummary
 	var err error
 	// updateMe is a channel to send a message to when we need to update signed
 	// urls because either we don't have any yet (i.e. first time) or they are
@@ -31,12 +29,10 @@ func SignedURLsManager() (chan chan *queue.PollTaskUrlsResponse, chan *queue.Pol
 		// When a worker wants to poll for pending tasks it must call
 		// `queue.pollTaskUrls(provisionerId, workerType)` which then returns
 		// an array of objects on the form `{signedPollUrl, signedDeleteUrl}`.
-		signedURLs, callSummary, err = Queue.PollTaskUrls(config.ProvisionerId, config.WorkerType)
+		signedURLs, err = Queue.PollTaskUrls(config.ProvisionerId, config.WorkerType)
 		// TODO: not sure if this is the right thing to do. If Queue has an outage, maybe better to
 		// do expoenential backoff indefinitely?
 		if err != nil {
-			log.Println("Http response was:")
-			log.Println(callSummary.HttpResponseBody)
 			panic(err)
 		}
 		// Set reminder to update signed urls again when they are

--- a/update-worker-type/update-worker-type.go
+++ b/update-worker-type/update-worker-type.go
@@ -34,7 +34,7 @@ func main() {
 	secretName := "project/taskcluster/aws-provisioner-v1/worker-types/ssh-keys/" + workerType
 
 	tcCreds := &tcclient.Credentials{
-		ClientId:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
+		ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
 		AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
 		Certificate: os.Getenv("TASKCLUSTER_CERTIFICATE"),
 	}
@@ -106,7 +106,7 @@ func main() {
 		log.Fatalf("Could not convert secret %#v to json: %v", sshSecret, err)
 	}
 
-	_, err = mySecrets.Set(
+	err = mySecrets.Set(
 		secretName,
 		&secrets.Secret{
 			Expires: tcclient.Time(time.Now().AddDate(1, 0, 0)),
@@ -116,7 +116,7 @@ func main() {
 	if err != nil {
 		log.Printf("Problem publishing new secrets: %v", err)
 	}
-	s, _, err := mySecrets.Get(secretName)
+	s, err := mySecrets.Get(secretName)
 	if err != nil {
 		log.Fatalf("Error retrieving secret: %v", err)
 	}


### PR DESCRIPTION
Upstream removed `CallSummary` and made some lint fixes.