### PR TITLE
Renamed all_commands.log to live_backing.log to fix links sent by mozilla-taskcluster to treeherder

### DIFF
--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -379,7 +379,7 @@ func TestUpload(t *testing.T) {
 	}
 
 	expectedArtifacts := map[string]string{
-		"public/logs/all_commands.log":   "hello world!\n",
+		"public/logs/live_backing.log":   "hello world!\n",
 		"public/logs/command_000000.log": "hello world!\n",
 		"SampleArtifacts/_/X.txt":        "test artifact\n",
 	}

--- a/livelog/livelog_test.go
+++ b/livelog/livelog_test.go
@@ -31,6 +31,11 @@ func TestLiveLog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not write test line to livelog:\n%s", err)
 	}
+	// This is required since livelog does not open the GET port until it first
+	// writes data to it, which probably should be fixed in the livelog
+	// codebase. Ideally it would serve both ports on initialisation, not
+	// requiring data to be PUT first.
+	waitForPortToBeActive(60023)
 	resp, err := http.Get(ll.GetURL)
 	if err != nil {
 		t.Fatalf("Could not GET livelog from URL %s:\n%s", ll.GetURL, err)

--- a/main.go
+++ b/main.go
@@ -922,7 +922,7 @@ func (task *TaskRun) run() error {
 }
 
 func (task *TaskRun) postTaskActions() error {
-	completeLogFile, err := os.Create(filepath.Join(TaskUser.HomeDir, "public", "logs", "all_commands.log"))
+	completeLogFile, err := os.Create(filepath.Join(TaskUser.HomeDir, "public", "logs", "live_backing.log"))
 	if err != nil {
 		return err
 	}
@@ -950,7 +950,7 @@ func (task *TaskRun) postTaskActions() error {
 		}
 	}
 	// will only upload if log concatenation succeeded
-	return task.uploadLog("public/logs/all_commands.log")
+	return task.uploadLog("public/logs/live_backing.log")
 }
 
 // writes config to json file


### PR DESCRIPTION
Thanks Greg!