### PR TITLE
Bug 1277568: redirect livelog artifact to underlying log when task command completes

### DIFF
--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -286,8 +286,11 @@ func TestUpload(t *testing.T) {
 			case *queueevents.ArtifactCreatedMessage:
 				a := message.(*queueevents.ArtifactCreatedMessage)
 				artifactCreatedMessages[a.Artifact.Name] = a
-				// finish after 3 artifacts have been created
-				if len(artifactCreatedMessages) == 3 {
+				// Finish after 4 artifacts have been created. Note: the second
+				// publish of the livelog artifact (for redirecting to the
+				// underlying file rather than the livelog stream) doesn't
+				// cause a new pulse message, hence this is 4 not 5.
+				if len(artifactCreatedMessages) == 4 {
 					// killWorkerChan <- true
 					// pulseConn.AMQPConn.Close()
 					artifactsCreatedChan <- true
@@ -379,9 +382,10 @@ func TestUpload(t *testing.T) {
 	}
 
 	expectedArtifacts := map[string]string{
-		"public/logs/live_backing.log":   "hello world!\n",
-		"public/logs/command_000000.log": "hello world!\n",
-		"SampleArtifacts/_/X.txt":        "test artifact\n",
+		"public/logs/live_backing.log":        "hello world!\n",
+		"public/logs/command_000000.log":      "hello world!\n",
+		"public/logs/command_000000.log.live": "hello world!\n",
+		"SampleArtifacts/_/X.txt":             "test artifact\n",
 	}
 
 	// wait for task to complete, so we know artifact upload also completed

--- a/main.go
+++ b/main.go
@@ -813,15 +813,7 @@ func (task *TaskRun) ExecuteCommand(index int) *CommandExecutionError {
 		return WorkerShutdown(err)
 	}
 
-	// the duration until the expiry is precisely -1 *
-	// the amount of time since the expiry
-	duration := -time.Since(time.Time(task.Definition.Expires))
-	commandLogURL, err := Queue.GetArtifact_SignedURL(
-		task.TaskId,
-		fmt.Sprintf("%v", task.RunId),
-		task.Commands[index].logFile,
-		duration,
-	)
+	commandLogURL := fmt.Sprintf("%v/task/%v/runs/%v/artifacts/%v", Queue.BaseURL, task.TaskId, task.RunId, url.QueryEscape(task.Commands[index].logFile))
 
 	if err != nil {
 		return WorkerShutdown(err)
@@ -835,7 +827,7 @@ func (task *TaskRun) ExecuteCommand(index int) *CommandExecutionError {
 				Expires: task.Definition.Expires,
 			},
 			MimeType: "text/plain; charset=utf-8",
-			URL:      commandLogURL.String(),
+			URL:      commandLogURL,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Hey Greg,

This should mirror docker worker behaviour, so that after a live log is no longer available, the livelog artifact is replaced by an alternative redirect artifact which points to the underlying log file.

The only difference is that we have one livelog per command in the Generic Worker, rather than just a single live log per task.