### PR TITLE
Bug 1279019: add artifact public/logs/worker_type_metadata.json to each task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
 
 script:
   - "go install -v ./..."
-  - "if test $GIMME_OS.$GIMME_ARCH = linux.amd64; then ${GOPATH}/bin/gotestcover -v -coverprofile=coverage.report ./...; go tool cover -func=coverage.report; fi"
+  - "if test $GIMME_OS.$GIMME_ARCH = linux.amd64; then ${GOPATH}/bin/gotestcover -v -coverprofile=coverage.report ./... && go tool cover -func=coverage.report; fi"
 
 after_script:
   - "$HOME/gopath/bin/goveralls -coverprofile=coverage.report -service=travis-ci"

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ go test -v ./...
 
 1. Bump the version number in `main.go` [here](https://github.com/taskcluster/generic-worker/blob/d1e48692122dd3e295defda1e61acc8509ad7e23/main.go#L58).
 2. Commit the change, e.g. `git add main.go; git commit -m "Bumped version number"`.
-3. Tag the repo, e.g. `git tag v2.0.0alpha2`
+3. Tag the repo, e.g. `git tag v2.0.1alpha2`
 4. Push to github taskcluster repo master branch, e.g. `git push; git push --tags`
 5. Wait for binary releases to magically appear [here](https://github.com/taskcluster/generic-worker/releases) (travis will push them if tests pass).
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ go test -v ./...
 
 1. Bump the version number in `main.go` [here](https://github.com/taskcluster/generic-worker/blob/d1e48692122dd3e295defda1e61acc8509ad7e23/main.go#L58).
 2. Commit the change, e.g. `git add main.go; git commit -m "Bumped version number"`.
-3. Tag the repo, e.g. `git tag v2.1.0alpha1`
+3. Tag the repo, e.g. `git tag v2.1.0alpha2`
 4. Push to github taskcluster repo master branch, e.g. `git push; git push --tags`
 5. Wait for binary releases to magically appear [here](https://github.com/taskcluster/generic-worker/releases) (travis will push them if tests pass).
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ go test -v ./...
 
 1. Bump the version number in `main.go` [here](https://github.com/taskcluster/generic-worker/blob/d1e48692122dd3e295defda1e61acc8509ad7e23/main.go#L58).
 2. Commit the change, e.g. `git add main.go; git commit -m "Bumped version number"`.
-3. Tag the repo, e.g. `git tag v2.1.0alpha5`
+3. Tag the repo, e.g. `git tag v2.1.0`
 4. Push to github taskcluster repo master branch, e.g. `git push; git push --tags`
 5. Wait for binary releases to magically appear [here](https://github.com/taskcluster/generic-worker/releases) (travis will push them if tests pass).
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ go test -v ./...
 
 1. Bump the version number in `main.go` [here](https://github.com/taskcluster/generic-worker/blob/d1e48692122dd3e295defda1e61acc8509ad7e23/main.go#L58).
 2. Commit the change, e.g. `git add main.go; git commit -m "Bumped version number"`.
-3. Tag the repo, e.g. `git tag v2.0.1alpha2`
+3. Tag the repo, e.g. `git tag v2.1.0alpha1`
 4. Push to github taskcluster repo master branch, e.g. `git push; git push --tags`
 5. Wait for binary releases to magically appear [here](https://github.com/taskcluster/generic-worker/releases) (travis will push them if tests pass).
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ go test -v ./...
 
 1. Bump the version number in `main.go` [here](https://github.com/taskcluster/generic-worker/blob/d1e48692122dd3e295defda1e61acc8509ad7e23/main.go#L58).
 2. Commit the change, e.g. `git add main.go; git commit -m "Bumped version number"`.
-3. Tag the repo, e.g. `git tag v2.1.0alpha3`
+3. Tag the repo, e.g. `git tag v2.1.0alpha4`
 4. Push to github taskcluster repo master branch, e.g. `git push; git push --tags`
 5. Wait for binary releases to magically appear [here](https://github.com/taskcluster/generic-worker/releases) (travis will push them if tests pass).
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ go test -v ./...
 
 1. Bump the version number in `main.go` [here](https://github.com/taskcluster/generic-worker/blob/d1e48692122dd3e295defda1e61acc8509ad7e23/main.go#L58).
 2. Commit the change, e.g. `git add main.go; git commit -m "Bumped version number"`.
-3. Tag the repo, e.g. `git tag v2.0.0`
+3. Tag the repo, e.g. `git tag v2.0.0alpha2`
 4. Push to github taskcluster repo master branch, e.g. `git push; git push --tags`
 5. Wait for binary releases to magically appear [here](https://github.com/taskcluster/generic-worker/releases) (travis will push them if tests pass).
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ go test -v ./...
 
 1. Bump the version number in `main.go` [here](https://github.com/taskcluster/generic-worker/blob/d1e48692122dd3e295defda1e61acc8509ad7e23/main.go#L58).
 2. Commit the change, e.g. `git add main.go; git commit -m "Bumped version number"`.
-3. Tag the repo, e.g. `git tag v2.1.0alpha2`
+3. Tag the repo, e.g. `git tag v2.1.0alpha3`
 4. Push to github taskcluster repo master branch, e.g. `git push; git push --tags`
 5. Wait for binary releases to magically appear [here](https://github.com/taskcluster/generic-worker/releases) (travis will push them if tests pass).
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ go test -v ./...
 
 1. Bump the version number in `main.go` [here](https://github.com/taskcluster/generic-worker/blob/d1e48692122dd3e295defda1e61acc8509ad7e23/main.go#L58).
 2. Commit the change, e.g. `git add main.go; git commit -m "Bumped version number"`.
-3. Tag the repo, e.g. `git tag v2.1.0alpha4`
+3. Tag the repo, e.g. `git tag v2.1.0alpha5`
 4. Push to github taskcluster repo master branch, e.g. `git push; git push --tags`
 5. Wait for binary releases to magically appear [here](https://github.com/taskcluster/generic-worker/releases) (travis will push them if tests pass).
 

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -265,10 +265,24 @@ func TestUpload(t *testing.T) {
 		PublicIP:                   net.ParseIP("127.0.0.1"),
 		Subdomain:                  "taskcluster-worker.net",
 		WorkerTypeMetadata: map[string]interface{}{
-			"generic-worker-version": version,
-			"go-version":             runtime.Version(),
-			"go-arch":                runtime.GOARCH,
-			"go-os":                  runtime.GOOS,
+			"aws": map[string]string{
+				"ami-id":            "test-ami",
+				"availability-zone": "test-aws-zone",
+				"instance-id":       "test-instance-id",
+				"instance-type":     "test-instance-type",
+				"public-ipv4":       "test-IP",
+			},
+			"generic-worker": map[string]string{
+				"go-arch":    runtime.GOARCH,
+				"go-os":      runtime.GOOS,
+				"go-version": runtime.Version(),
+				"release":    "test-release-url",
+				"version":    version,
+			},
+			"machine-setup": map[string]string{
+				"maintainer": "pmoore@mozilla.com",
+				"script":     "test-script-url",
+			},
 		},
 	}
 

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -264,7 +264,7 @@ func TestUpload(t *testing.T) {
 		LiveLogSecret:              "xyz",
 		PublicIP:                   net.ParseIP("127.0.0.1"),
 		Subdomain:                  "taskcluster-worker.net",
-		WorkerTypeMetaData: map[string]interface{}{
+		WorkerTypeMetadata: map[string]interface{}{
 			"generic-worker-version": version,
 			"go-version":             runtime.Version(),
 			"go-arch":                runtime.GOARCH,

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -263,6 +264,12 @@ func TestUpload(t *testing.T) {
 		LiveLogSecret:              "xyz",
 		PublicIP:                   net.ParseIP("127.0.0.1"),
 		Subdomain:                  "taskcluster-worker.net",
+		WorkerTypeMetaData: map[string]interface{}{
+			"generic-worker-version": version,
+			"go-version":             runtime.Version(),
+			"go-arch":                runtime.GOARCH,
+			"go-os":                  runtime.GOOS,
+		},
 	}
 
 	// get the worker started
@@ -286,11 +293,11 @@ func TestUpload(t *testing.T) {
 			case *queueevents.ArtifactCreatedMessage:
 				a := message.(*queueevents.ArtifactCreatedMessage)
 				artifactCreatedMessages[a.Artifact.Name] = a
-				// Finish after 4 artifacts have been created. Note: the second
+				// Finish after 5 artifacts have been created. Note: the second
 				// publish of the livelog artifact (for redirecting to the
 				// underlying file rather than the livelog stream) doesn't
-				// cause a new pulse message, hence this is 4 not 5.
-				if len(artifactCreatedMessages) == 4 {
+				// cause a new pulse message, hence this is 5 not 6.
+				if len(artifactCreatedMessages) == 5 {
 					// killWorkerChan <- true
 					// pulseConn.AMQPConn.Close()
 					artifactsCreatedChan <- true
@@ -412,6 +419,15 @@ func TestUpload(t *testing.T) {
 				t.Errorf("Artifact '%s' not created", artifact)
 			}
 		}
+	}
+
+	// Check worker type metadata is there
+	if a := artifactCreatedMessages["public/logs/worker_type_metadata.json"]; a != nil {
+		if a.Artifact.ContentType != "text/plain; charset=utf-8" {
+			t.Errorf("Artifact 'public/logs/worker_type_metadata.json' should have mime type 'text/plain; charset=utf-8' but has '%s'", a.Artifact.ContentType)
+		}
+	} else {
+		t.Error("Artifact 'public/logs/worker_type_metadata.json' not created")
 	}
 
 	// now check content was uploaded to Amazon, and is correct

--- a/aws.go
+++ b/aws.go
@@ -214,7 +214,7 @@ func (c *Config) updateConfigWithAmazonSettings() error {
 	}
 
 	// Now overlay existing config with values in secrets
-	json.Unmarshal(secrets.GenericWorker.Config, c)
+	err = c.mergeInJSON([]byte(secrets.GenericWorker.Config))
 	if err != nil {
 		return err
 	}

--- a/aws.go
+++ b/aws.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/taskcluster/httpbackoff"
@@ -31,7 +32,7 @@ func queryUserData() (*UserData, error) {
 	return userData, err
 }
 
-func queryMetaData(url, name string) (string, error) {
+func queryMetaData(url string) (string, error) {
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-retrieval
 	// call http://169.254.169.254/latest/meta-data/instance-id with httpbackoff
 	resp, _, err := httpbackoff.Get(url)
@@ -40,16 +41,7 @@ func queryMetaData(url, name string) (string, error) {
 	}
 	defer resp.Body.Close()
 	content, err := ioutil.ReadAll(resp.Body)
-	fmt.Println(name + ": " + string(content))
 	return string(content), err
-}
-
-func queryInstanceName() (string, error) {
-	return queryMetaData("http://169.254.169.254/latest/meta-data/instance-id", "Instance name")
-}
-
-func queryPublicIP() (string, error) {
-	return queryMetaData("http://169.254.169.254/latest/meta-data/public-ipv4", "Public IP")
 }
 
 type UserData struct {
@@ -179,14 +171,6 @@ func (c *Config) updateConfigWithAmazonSettings() error {
 	if err != nil {
 		return err
 	}
-	instanceName, err := queryInstanceName()
-	if err != nil {
-		return err
-	}
-	publicIP, err := queryPublicIP()
-	if err != nil {
-		return err
-	}
 	c.ProvisionerId = userData.ProvisionerId
 	awsprov := awsprovisioner.AwsProvisioner{
 		Authenticate: false,
@@ -205,9 +189,24 @@ func (c *Config) updateConfigWithAmazonSettings() error {
 	c.ClientId = secToken.Credentials.ClientID
 	c.Certificate = secToken.Credentials.Certificate
 	c.WorkerGroup = userData.Region
-	c.WorkerId = instanceName
-	c.PublicIP = net.ParseIP(publicIP)
 	c.WorkerType = userData.WorkerType
+
+	awsMetadata := map[string]interface{}{}
+	for _, url := range []string{
+		"http://169.254.169.254/latest/meta-data/ami-id",
+		"http://169.254.169.254/latest/meta-data/instance-id",
+		"http://169.254.169.254/latest/meta-data/instsance-type",
+		"http://169.254.169.254/latest/meta-data/public-ipv4",
+		"http://169.254.169.254/latest/meta-data/placement/availability-zone",
+	} {
+		key := url[strings.LastIndex(url, "/")+1:]
+		// if we get an error, be ok with it, it isn't sooooo important
+		value, _ := queryMetaData(url)
+		awsMetadata[key] = value
+	}
+	c.WorkerTypeMetadata["aws"] = awsMetadata
+	c.WorkerId = awsMetadata["instance-id"].(string)
+	c.PublicIP = net.ParseIP(awsMetadata["public-ipv4"].(string))
 	secrets := new(Secrets)
 	json.Unmarshal(secToken.Data, secrets)
 	if err != nil {

--- a/aws.go
+++ b/aws.go
@@ -195,7 +195,7 @@ func (c *Config) updateConfigWithAmazonSettings() error {
 	for _, url := range []string{
 		"http://169.254.169.254/latest/meta-data/ami-id",
 		"http://169.254.169.254/latest/meta-data/instance-id",
-		"http://169.254.169.254/latest/meta-data/instsance-type",
+		"http://169.254.169.254/latest/meta-data/instance-type",
 		"http://169.254.169.254/latest/meta-data/public-ipv4",
 		"http://169.254.169.254/latest/meta-data/placement/availability-zone",
 	} {

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"net"
+	"runtime"
 	"testing"
 )
 
@@ -81,5 +82,25 @@ func TestMissingConfigFile(t *testing.T) {
 		// all ok
 	default:
 		t.Fatalf("Was expecting an error of type MissingConfigError but received error of type %T", err)
+	}
+}
+
+func TestWorkerTypeMetadata(t *testing.T) {
+	const file = "test/config/worker-type-metadata.json"
+	config, err := loadConfig(file, false)
+	if err != nil {
+		t.Fatalf("Config should pass validation, but get:\n%s", err)
+	}
+	// loadConfig function specifies a value, let's check we can override it in the config file
+	if config.WorkerTypeMetaData["go-os"] != "fakeos" {
+		t.Fatal("Was expecting key 'go-os' from file worker-type-metadata.json to override default value")
+	}
+	// go-version not specified in config file, but should be set in loadConfig, let's check it is
+	if config.WorkerTypeMetaData["go-version"] != runtime.Version() {
+		t.Fatal("Was expecting key 'go-version' to be set to go version in worker type metadata")
+	}
+	// machine-setup is not set in loadConfig, but is set in config file, let's check we have it
+	if config.WorkerTypeMetaData["machine-setup"] != "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata" {
+		t.Fatal("Was expecting machine-setup to be set properly")
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -92,15 +92,15 @@ func TestWorkerTypeMetadata(t *testing.T) {
 		t.Fatalf("Config should pass validation, but get:\n%s", err)
 	}
 	// loadConfig function specifies a value, let's check we can override it in the config file
-	if config.WorkerTypeMetadata["go-os"] != "fakeos" {
-		t.Fatal("Was expecting key 'go-os' from file worker-type-metadata.json to override default value")
+	if config.WorkerTypeMetadata["generic-worker"].(map[string]interface{})["go-os"] != "fakeos" {
+		t.Fatalf("Was expecting key 'go-os' from file worker-type-metadata.json to override default value\n%#v", config)
 	}
 	// go-version not specified in config file, but should be set in loadConfig, let's check it is
-	if config.WorkerTypeMetadata["go-version"] != runtime.Version() {
-		t.Fatal("Was expecting key 'go-version' to be set to go version in worker type metadata")
+	if config.WorkerTypeMetadata["generic-worker"].(map[string]interface{})["go-version"] != runtime.Version() {
+		t.Fatalf("Was expecting key 'go-version' to be set to go version in worker type metadata\n%#v", config)
 	}
 	// machine-setup is not set in loadConfig, but is set in config file, let's check we have it
-	if config.WorkerTypeMetadata["machine-setup"] != "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata" {
-		t.Fatal("Was expecting machine-setup to be set properly")
+	if config.WorkerTypeMetadata["machine-setup"].(map[string]interface{})["script"] != "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata" {
+		t.Fatalf("Was expecting machine-setup to be set properly\n%#v", config)
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -92,15 +92,15 @@ func TestWorkerTypeMetadata(t *testing.T) {
 		t.Fatalf("Config should pass validation, but get:\n%s", err)
 	}
 	// loadConfig function specifies a value, let's check we can override it in the config file
-	if config.WorkerTypeMetaData["go-os"] != "fakeos" {
+	if config.WorkerTypeMetadata["go-os"] != "fakeos" {
 		t.Fatal("Was expecting key 'go-os' from file worker-type-metadata.json to override default value")
 	}
 	// go-version not specified in config file, but should be set in loadConfig, let's check it is
-	if config.WorkerTypeMetaData["go-version"] != runtime.Version() {
+	if config.WorkerTypeMetadata["go-version"] != runtime.Version() {
 		t.Fatal("Was expecting key 'go-version' to be set to go version in worker type metadata")
 	}
 	// machine-setup is not set in loadConfig, but is set in config file, let's check we have it
-	if config.WorkerTypeMetaData["machine-setup"] != "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata" {
+	if config.WorkerTypeMetadata["machine-setup"] != "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata" {
 		t.Fatal("Was expecting machine-setup to be set properly")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ var (
 	config             *Config
 	configFile         string
 
-	version = "generic-worker 2.0.0alpha2"
+	version = "generic-worker 2.0.1alpha2"
 	usage   = `
 generic-worker
 generic-worker is a taskcluster worker that can run on any platform that supports go (golang).

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ var (
 	config             *Config
 	configFile         string
 
-	version = "generic-worker 2.1.0alpha1"
+	version = "2.1.0alpha2"
 	usage   = `
 generic-worker
 generic-worker is a taskcluster worker that can run on any platform that supports go (golang).
@@ -210,7 +210,7 @@ and reports back results to the queue.
 
 // Entry point into the generic worker...
 func main() {
-	arguments, err := docopt.Parse(usage, nil, true, version, false, true)
+	arguments, err := docopt.Parse(usage, nil, true, "generic-worker "+version, false, true)
 	if err != nil {
 		fmt.Println("Error parsing command line arguments!")
 		panic(err)
@@ -267,11 +267,13 @@ func loadConfig(filename string, queryUserData bool) (*Config, error) {
 		CleanUpTaskDirs:            true,
 		IdleShutdownTimeoutSecs:    0,
 		WorkerTypeMetadata: map[string]interface{}{
-			"generic-worker-version": version,
-			"generic-worker-source":  "https://github.com/taskcluster/generic-worker/releases",
-			"go-version":             runtime.Version(),
-			"go-arch":                runtime.GOARCH,
-			"go-os":                  runtime.GOOS,
+			"generic-worker": map[string]string{
+				"go-arch":    runtime.GOARCH,
+				"go-os":      runtime.GOOS,
+				"go-version": runtime.Version(),
+				"release":    "https://github.com/taskcluster/generic-worker/releases/tag/v" + version,
+				"version":    version,
+			},
 		},
 	}
 	// try to open config file...

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ var (
 	config             *Config
 	configFile         string
 
-	version = "2.1.0alpha4"
+	version = "2.1.0alpha5"
 	usage   = `
 generic-worker
 generic-worker is a taskcluster worker that can run on any platform that supports go (golang).

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ var (
 	config             *Config
 	configFile         string
 
-	version = "generic-worker 2.0.1alpha2"
+	version = "generic-worker 2.1.0alpha1"
 	usage   = `
 generic-worker
 generic-worker is a taskcluster worker that can run on any platform that supports go (golang).

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ var (
 	config             *Config
 	configFile         string
 
-	version = "2.1.0alpha5"
+	version = "2.1.0"
 	usage   = `
 generic-worker
 generic-worker is a taskcluster worker that can run on any platform that supports go (golang).

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ var (
 	config             *Config
 	configFile         string
 
-	version = "generic-worker 2.0.0"
+	version = "generic-worker 2.0.0alpha2"
 	usage   = `
 generic-worker
 generic-worker is a taskcluster worker that can run on any platform that supports go (golang).

--- a/mergeconfig.go
+++ b/mergeconfig.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/peterbourgon/mergemap"
+)
+
+func (c *Config) mergeInJSON(data []byte) error {
+	// This is all HORRIBLE
+	// but it seems about the only reasonable way to properly merge
+	// the json schemas such that json objects are recursively merged.
+	// Steps: convert c to json and then back to a go type, so that
+	// it is a map[string]interface{} and not a Config type. Get
+	// the json bytes also into a map[string]interface{} so that
+	// the two map[string]interface{} objects can be merged. Finally
+	// convert the merge result to json again so that it can be
+	// marshaled back into the original Config type... Yuck!
+	m1 := new(map[string]interface{})
+	m2 := new(map[string]interface{})
+	m1bytes, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(m1bytes, m1)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(data, m2)
+	if err != nil {
+		return err
+	}
+	merged := mergemap.Merge(*m1, *m2)
+	mergedBytes, err := json.Marshal(merged)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(mergedBytes, c)
+}

--- a/model.go
+++ b/model.go
@@ -18,23 +18,24 @@ type ExecCommand interface {
 type (
 	// Generic Worker config
 	Config struct {
-		AccessToken                string `json:"accessToken"`
-		ClientId                   string `json:"clientId"`
-		LiveLogCertificate         string `json:"livelogCertificate"`
-		LiveLogExecutable          string `json:"livelogExecutable"`
-		LiveLogKey                 string `json:"livelogKey"`
-		LiveLogSecret              string `json:"livelogSecret"`
-		Certificate                string `json:"certificate"`
-		ProvisionerId              string `json:"provisionerId"`
-		RefreshUrlsPrematurelySecs int    `json:"refreshURLsPrematurelySecs"`
-		PublicIP                   net.IP `json:"publicIP"`
-		Subdomain                  string `json:"subdomain"`
-		WorkerGroup                string `json:"workerGroup"`
-		WorkerId                   string `json:"workerId"`
-		WorkerType                 string `json:"workerType"`
-		UsersDir                   string `json:"usersDir"`
-		CleanUpTaskDirs            bool   `json:"cleanUpTaskDirs"`
-		IdleShutdownTimeoutSecs    int    `json:"idleShutdownTimeoutSecs"`
+		AccessToken                string                 `json:"accessToken"`
+		ClientId                   string                 `json:"clientId"`
+		LiveLogCertificate         string                 `json:"livelogCertificate"`
+		LiveLogExecutable          string                 `json:"livelogExecutable"`
+		LiveLogKey                 string                 `json:"livelogKey"`
+		LiveLogSecret              string                 `json:"livelogSecret"`
+		Certificate                string                 `json:"certificate"`
+		ProvisionerId              string                 `json:"provisionerId"`
+		RefreshUrlsPrematurelySecs int                    `json:"refreshURLsPrematurelySecs"`
+		PublicIP                   net.IP                 `json:"publicIP"`
+		Subdomain                  string                 `json:"subdomain"`
+		WorkerGroup                string                 `json:"workerGroup"`
+		WorkerId                   string                 `json:"workerId"`
+		WorkerType                 string                 `json:"workerType"`
+		UsersDir                   string                 `json:"usersDir"`
+		CleanUpTaskDirs            bool                   `json:"cleanUpTaskDirs"`
+		IdleShutdownTimeoutSecs    int                    `json:"idleShutdownTimeoutSecs"`
+		WorkerTypeMetaData         map[string]interface{} `json:"workerTypeMetaData"`
 	}
 
 	// Used for modelling the xml we get back from Azure

--- a/model.go
+++ b/model.go
@@ -35,7 +35,7 @@ type (
 		UsersDir                   string                 `json:"usersDir"`
 		CleanUpTaskDirs            bool                   `json:"cleanUpTaskDirs"`
 		IdleShutdownTimeoutSecs    int                    `json:"idleShutdownTimeoutSecs"`
-		WorkerTypeMetaData         map[string]interface{} `json:"workerTypeMetaData"`
+		WorkerTypeMetadata         map[string]interface{} `json:"workerTypeMetadata"`
 	}
 
 	// Used for modelling the xml we get back from Azure

--- a/plat_all-unix-style.go
+++ b/plat_all-unix-style.go
@@ -32,13 +32,23 @@ func immediateShutdown() {
 	}
 }
 
-func startup() error {
-	log.Printf("Detected %s platform", runtime.GOOS)
+// we put this in init() instead of startup() as we want tests to be able to change
+// it - note we shouldn't have these nasty global vars, I can only apologise, and
+// say taskcluster-worker will be much nicer
+func init() {
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
 	TaskUser = OSUser{
-		HomeDir:  os.Getwd(),
+		HomeDir:  pwd,
 		Name:     "",
 		Password: "",
 	}
+}
+
+func startup() error {
+	log.Printf("Detected %s platform", runtime.GOOS)
 	return os.MkdirAll(filepath.Join(TaskUser.HomeDir, "public", "logs"), 0700)
 }
 

--- a/plat_all-unix-style.go
+++ b/plat_all-unix-style.go
@@ -34,16 +34,17 @@ func immediateShutdown() {
 
 func startup() error {
 	log.Printf("Detected %s platform", runtime.GOOS)
-	return nil
+	TaskUser = OSUser{
+		HomeDir:  os.Getwd(),
+		Name:     "",
+		Password: "",
+	}
+	return os.MkdirAll(filepath.Join(TaskUser.HomeDir, "public", "logs"), 0700)
 }
 
 func (task *TaskRun) generateCommand(index int, writer io.Writer) error {
 	cmd := exec.Command(task.Payload.Command[index][0], task.Payload.Command[index][1:]...)
 	commandName := fmt.Sprintf("command_%06d", index)
-	err := os.MkdirAll(filepath.Join(TaskUser.HomeDir, "public", "logs"), 0700)
-	if err != nil {
-		return err
-	}
 	log, err := os.Create(filepath.Join(TaskUser.HomeDir, "public", "logs", commandName+".log"))
 	if err != nil {
 		return err

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 cd "$(dirname "${0}")"
 git grep -l 'alpha' | while read file; do

--- a/release.sh
+++ b/release.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "${0}")"
 git grep -l 'alpha' | while read file; do
   cp "${file}" "${file}.copy"
-  cat "${file}.copy" | sed 's/2\.0\.0alpha[0-9]*/'"${1}"'/g' > "${file}"
+  cat "${file}.copy" | sed 's/2\.[0-9][0-9]*\.[0-9][0-9]*alpha[0-9]*/'"${1}"'/g' > "${file}"
   rm "${file}.copy"
   git add "${file}"
 done

--- a/test/config/worker-type-metadata.json
+++ b/test/config/worker-type-metadata.json
@@ -7,9 +7,14 @@
   "workerType" : "some-worker-type",
   "publicIP" : "2.1.2.1",
   "workerTypeMetadata": {
-    "generic-worker-version": "generic-worker 2.0.0",
-    "go-arch": "amd64",
-    "go-os": "fakeos",
-    "machine-setup": "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata"
+    "generic-worker": {
+      "version": "generic-worker 2.0.0",
+      "go-arch": "amd64",
+      "go-os": "fakeos"
+    },
+    "machine-setup": {
+      "maintainer": "pmoore@mozilla.com",
+      "script": "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata"
+    }
   }
 }

--- a/test/config/worker-type-metadata.json
+++ b/test/config/worker-type-metadata.json
@@ -1,0 +1,15 @@
+{
+  "livelogSecret" : "this-is-a-secret",
+  "clientId" : "test-client",
+  "workerId" : "myworkerid",
+  "accessToken" : "V7w5mcc3Q3mQHp3ns0C7dA",
+  "workerGroup" : "abcde",
+  "workerType" : "some-worker-type",
+  "publicIP" : "2.1.2.1",
+  "workerTypeMetadata": {
+    "generic-worker-version": "generic-worker 2.0.0",
+    "go-arch": "amd64",
+    "go-os": "fakeos",
+    "machine-setup": "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata"
+  }
+}

--- a/worker_types/ttaubert-win2012r2/userdata
+++ b/worker_types/ttaubert-win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.0.1alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha1/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/ttaubert-win2012r2/userdata
+++ b/worker_types/ttaubert-win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha5/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/ttaubert-win2012r2/userdata
+++ b/worker_types/ttaubert-win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha3/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha4/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/ttaubert-win2012r2/userdata
+++ b/worker_types/ttaubert-win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha3/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/ttaubert-win2012r2/userdata
+++ b/worker_types/ttaubert-win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha1/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/ttaubert-win2012r2/userdata
+++ b/worker_types/ttaubert-win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.0.0alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.0.1alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/ttaubert-win2012r2/userdata
+++ b/worker_types/ttaubert-win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha4/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha5/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/ttaubert-win2012r2/userdata
+++ b/worker_types/ttaubert-win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.0.0/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.0.0alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/win2012r2/userdata
+++ b/worker_types/win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.0.1alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha1/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/win2012r2/userdata
+++ b/worker_types/win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha5/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/win2012r2/userdata
+++ b/worker_types/win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha3/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha4/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/win2012r2/userdata
+++ b/worker_types/win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha3/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/win2012r2/userdata
+++ b/worker_types/win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha1/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/win2012r2/userdata
+++ b/worker_types/win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.0.0alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.0.1alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/win2012r2/userdata
+++ b/worker_types/win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha4/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.1.0alpha5/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/win2012r2/userdata
+++ b/worker_types/win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.0.0/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v2.0.0alpha2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")


### PR DESCRIPTION
This is a place for storing information about how the worker type was set up. In the worker type definition, a json object can be set in `secrets.generic-worker.config.workerTypeMetadata` for adding extra data into `public/logs/worker_type_metadata.json`. Note, it comes with some default fields, which can be overridden or added to:
```json
{
  "generic-worker-version": <generic-worker-version>,
  "go-version":             runtime.Version(),
  "go-arch":                runtime.GOARCH,
  "go-os":                  runtime.GOOS
}
```
It is intended that this would be used for storing a link to the machine setup, _for example_, by adding something like this to the worker type definition:
```
{
  "secrets": {
    "generic-worker": {
      "config": {
        "workerTypeMetadata": {
          "machine-setup": "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata",
          "maintainer": "pmoore@mozilla.com"
        }
      }
    }
  }
}
```

The idea is that whenever the worker type is updated, this metadata can be refreshed, so anybody running a test can see the metadata about how the worker type was set up that ran their task. This is useful especially on Windows, where the toolchains for the tasks are installed directly in the worker type, rather than in e.g. a docker container like we do on linux.