### PR TITLE
use a lower case username

### DIFF
--- a/plat_windows.go
+++ b/plat_windows.go
@@ -102,7 +102,7 @@ func deleteHomeDir(path string, user string) error {
 func createNewTaskUser() error {
 	// username can only be 20 chars, uuids are too long, therefore
 	// use prefix (5 chars) plus seconds since epoch (10 chars)
-	userName := "Task_" + strconv.Itoa((int)(time.Now().Unix()))
+	userName := "task_" + strconv.Itoa((int)(time.Now().Unix()))
 	password := generatePassword()
 	TaskUser = OSUser{
 		HomeDir:  filepath.Join(config.UsersDir, userName),


### PR DESCRIPTION
Due to problems in the Firefox build process (for Windows), the upper case "T" in the username highlights numerous bugs in that build code. This patch bypasses those issues by not creating paths that the build process can choke on. Eg: see https://bugzilla.mozilla.org/show_bug.cgi?id=1280326