### PR TITLE
Bug 1285197 - fix go get warning for taskcluster-client-go

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/taskcluster/httpbackoff"
 	"github.com/taskcluster/stateless-dns-go/hostname"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/queue"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
 type (

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/taskcluster/httpbackoff"
 	"github.com/taskcluster/pulse-go/pulse"
 	"github.com/taskcluster/slugid-go/slugid"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/queue"
 	"github.com/taskcluster/taskcluster-client-go/queueevents"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ import (
 	docopt "github.com/docopt/docopt-go"
 	"github.com/taskcluster/generic-worker/livelog"
 	"github.com/taskcluster/httpbackoff"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/queue"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 	"github.com/xeipuuv/gojsonschema"
 )
 

--- a/payloadmodel.go
+++ b/payloadmodel.go
@@ -4,7 +4,7 @@
 
 package main
 
-import "github.com/taskcluster/taskcluster-client-go/tcclient"
+import tcclient "github.com/taskcluster/taskcluster-client-go"
 
 type (
 	// This schema defines the structure of the `payload` property referred to

--- a/plat_windows.go
+++ b/plat_windows.go
@@ -18,7 +18,7 @@ import (
 	"github.com/contester/runlib/subprocess"
 	"github.com/dchest/uniuri"
 	"github.com/taskcluster/generic-worker/os/exec"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"golang.org/x/sys/windows/registry"
 )
 

--- a/show-workers/main.go
+++ b/show-workers/main.go
@@ -14,8 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/secrets"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
 func main() {

--- a/update-worker-type/update-worker-type.go
+++ b/update-worker-type/update-worker-type.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/secrets"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
 func main() {


### PR DESCRIPTION
This depends on taskcluster/taskcluster-client-go#15 so I would expect travis to fail for this PR until that has landed. When the other PR lands, you should be able to rerun the travis jobs on this PR.