### PR TITLE
One livelog per task, instead of per command

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -269,11 +269,11 @@ func canonicalPath(path string) string {
 	return strings.Replace(path, string(os.PathSeparator), "/", -1)
 }
 
-func (task *TaskRun) uploadLiveLog(index int) error {
+func (task *TaskRun) uploadLiveLog() error {
 	maxRunTimeDeadline := time.Time(task.TaskClaimResponse.Status.Runs[task.RunId].Started).Add(time.Duration(task.Payload.MaxRunTime) * time.Second)
 	// deduce stateless DNS name to use
 	statelessHostname := hostname.New(config.PublicIP, config.Subdomain, maxRunTimeDeadline, config.LiveLogSecret)
-	getURL, err := url.Parse(task.Commands[index].liveLog.GetURL)
+	getURL, err := url.Parse(task.liveLog.GetURL)
 	if err != nil {
 		return err
 	}
@@ -282,7 +282,7 @@ func (task *TaskRun) uploadLiveLog(index int) error {
 	return task.uploadArtifact(
 		RedirectArtifact{
 			BaseArtifact: BaseArtifact{
-				CanonicalPath: task.Commands[index].logFile + ".live",
+				CanonicalPath: "public/logs/live.log",
 				// livelog expires when task must have completed
 				Expires: tcclient.Time(maxRunTimeDeadline),
 			},

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -310,8 +310,8 @@ func TestUpload(t *testing.T) {
 				// Finish after 5 artifacts have been created. Note: the second
 				// publish of the livelog artifact (for redirecting to the
 				// underlying file rather than the livelog stream) doesn't
-				// cause a new pulse message, hence this is 5 not 6.
-				if len(artifactCreatedMessages) == 5 {
+				// cause a new pulse message, hence this is 4 not 5.
+				if len(artifactCreatedMessages) == 4 {
 					// killWorkerChan <- true
 					// pulseConn.AMQPConn.Close()
 					artifactsCreatedChan <- true
@@ -372,6 +372,10 @@ func TestUpload(t *testing.T) {
 				[
 					"echo",
 					"hello world!"
+				],
+				[
+					"echo",
+					"goodbye world!"
 				]
 			],
 			"maxRunTime": 7200,
@@ -403,10 +407,9 @@ func TestUpload(t *testing.T) {
 	}
 
 	expectedArtifacts := map[string]string{
-		"public/logs/live_backing.log":        "hello world!\n",
-		"public/logs/command_000000.log":      "hello world!\n",
-		"public/logs/command_000000.log.live": "hello world!\n",
-		"SampleArtifacts/_/X.txt":             "test artifact\n",
+		"public/logs/live_backing.log": "hello world!\ngoodbye world!\n",
+		"public/logs/live.log":         "hello world!\ngoodbye world!\n",
+		"SampleArtifacts/_/X.txt":      "test artifact\n",
 	}
 
 	// wait for task to complete, so we know artifact upload also completed

--- a/model.go
+++ b/model.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net"
 	"time"
 
@@ -73,6 +74,11 @@ type (
 		Commands            []Command                    `json:"-"`
 		// not exported
 		reclaimTimer *time.Timer
+		logWriter    io.Writer
+		// The canonical name of the log file as reported to the Queue, which
+		// is typically the relative location of the log file to the user home
+		// directory
+		liveLog *livelog.LiveLog
 	}
 
 	// Regardless of platform, we will have to call out to system commands to run tasks,
@@ -82,8 +88,6 @@ type (
 		// The canonical name of the log file as reported to the Queue, which
 		// is typically the relative location of the log file to the user home
 		// directory
-		logFile string
-		liveLog *livelog.LiveLog
 	}
 
 	// Custom time format to enable unmarshalling of azure xml directly into go

--- a/plat_all-unix-style.go
+++ b/plat_all-unix-style.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"fmt"
-	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -52,20 +50,14 @@ func startup() error {
 	return os.MkdirAll(filepath.Join(TaskUser.HomeDir, "public", "logs"), 0700)
 }
 
-func (task *TaskRun) generateCommand(index int, writer io.Writer) error {
+func (task *TaskRun) generateCommand(index int) error {
 	cmd := exec.Command(task.Payload.Command[index][0], task.Payload.Command[index][1:]...)
-	commandName := fmt.Sprintf("command_%06d", index)
-	log, err := os.Create(filepath.Join(TaskUser.HomeDir, "public", "logs", commandName+".log"))
-	if err != nil {
-		return err
-	}
-	multiWriter := io.MultiWriter(writer, log)
-	cmd.Stdout = multiWriter
-	cmd.Stderr = multiWriter
+	cmd.Stdout = task.logWriter
+	cmd.Stderr = task.logWriter
 	// cmd.Stdout = log
 	// cmd.Stderr = log
 	task.prepEnvVars(cmd)
-	task.Commands[index] = Command{osCommand: cmd, logFile: "public/logs/" + commandName + ".log"}
+	task.Commands[index] = Command{osCommand: cmd}
 	return nil
 }
 


### PR DESCRIPTION
To be consistent with docker worker.