### PR TITLE
Use credentials from queue.ClaimTask response for uploading artifacts

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -313,7 +313,7 @@ func (task *TaskRun) uploadArtifact(artifact Artifact) error {
 		return err
 	}
 	par := queue.PostArtifactRequest(json.RawMessage(payload))
-	parsp, err := Queue.CreateArtifact(
+	parsp, err := task.Queue.CreateArtifact(
 		task.TaskId,
 		strconv.Itoa(int(task.RunId)),
 		artifact.Base().CanonicalPath,

--- a/model.go
+++ b/model.go
@@ -79,6 +79,7 @@ type (
 		// is typically the relative location of the log file to the user home
 		// directory
 		liveLog *livelog.LiveLog
+		Queue   *queue.Queue `json:"-"`
 	}
 
 	// Regardless of platform, we will have to call out to system commands to run tasks,


### PR DESCRIPTION
This should mean we no longer need to grant `queue:create-artifact:*` to all worker types that use generic worker.