### PR TITLE
show worker type at start of task log

### DIFF
--- a/main.go
+++ b/main.go
@@ -915,7 +915,7 @@ func (task *TaskRun) run() error {
 	if err != nil {
 		return WorkerShutdown(err)
 	}
-	task.Log("Worker Type settings:")
+	task.Log("Worker Type (" + config.WorkerType + ") settings:")
 	task.Log("  " + string(jsonBytes))
 	task.Log("=== Task Starting ===")
 	started := time.Now()


### PR DESCRIPTION
with more worker types taking jobs (win 7, 10 testers), it's handy to be able to see quickly which worker type is running the task