### PR TITLE
Bug 1298010 - shut down worker type if deploymentId has updated in worker type config

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ go test -v ./...
 Run the `release.sh` script like so:
 
 ```
-$ ./release.sh 6.0.9
+$ ./release.sh 6.1.0alpha1
 ```
 
 This will perform some checks, tag the repo, push the tag to github, which will then trigger travis-ci to run tests, and publish the new release.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ and reports back results to the queue.
                                             for serving live logs; see
                                             https://github.com/taskcluster/livelog and
                                             https://github.com/taskcluster/stateless-dns-server
+          signingKeyLocation                The PGP signing key for signing artifacts with.
 
         ** OPTIONAL ** properties
         =========================
@@ -156,6 +157,11 @@ and reports back results to the queue.
                                             over https. If not set, http will be used.
           usersDir                          The location where user home directories should be
                                             created on the worker. [default: C:\Users]
+          downloadsDir                      The location where resources are downloaded for
+                                            populating preloaded caches and readonly mounts.
+                                            [default: C:\generic-worker\downloads]
+          cachesDir                         The location where task caches should be stored on
+                                            the worker. [default: C:\generic-worker\caches]
           cleanUpTaskDirs                   Whether to delete the home directories of the task
                                             users after the task completes. Normally you would
                                             want to do this to avoid filling up disk space,
@@ -175,12 +181,32 @@ and reports back results to the queue.
                                             will have more information about how it was set up
                                             (for example what has been installed on the
                                             machine).
-          signingKeyLocation                The PGP signing key for signing artifacts with.
-                                            If not set, tasks will not be signed.
           runTasksAsCurrentUser             If true, users will not be created for tasks, but
                                             the current OS user will be used. Useful if not an
                                             administrator, e.g. when running tests. Should not
                                             be used in production! [default: false]
+          requiredDiskSpaceMegabytes        The garbage collector will ensure at least this
+                                            number of megabytes of disk space are available
+                                            when each task starts. If it cannot free enough
+                                            disk space, the worker will shut itself down.
+                                            [default: 10240]
+          shutdownMachineOnInternalError    If true, if the worker encounters an unrecoverable
+                                            error (such as not being able to write to a
+                                            required file) it will shutdown the host
+                                            computer. Note this is generally only desired
+                                            for machines running in production, such as on AWS
+                                            EC2 spot instances. Use with caution!
+                                            [default: false]
+          numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after
+                                            this many tasks, exit. [default: 0]
+          deploymentId                      If running with --configure-for-aws, then between
+                                            tasks, at a maximum frequency of once per 30 mins,
+                                            the worker will query the provisioner to get the
+                                            updated worker type definition. If the deploymentId
+                                            in the config of the worker type definition is
+                                            different to the worker's current deploymentId, the
+                                            worker will shut itself down. See
+                                            https://bugzil.la/1298010
 
     Here is an syntactically valid example configuration file:
 
@@ -192,7 +218,8 @@ and reports back results to the queue.
               "workerType":                 "win2008-worker",
               "provisionerId":              "my-provisioner",
               "livelogSecret":              "baNaNa-SouP4tEa",
-              "publicIP":                   "12.24.35.46"
+              "publicIP":                   "12.24.35.46",
+              "signingKeyLocation":         "C:\\generic-worker\\generic-worker-gpg-signing-key.key"
             }
 
 

--- a/clean-builds.sh
+++ b/clean-builds.sh
@@ -18,7 +18,13 @@ rm -rf target
 mkdir target
 
 export GO_DOWNLOAD_DIR="$(mktemp -d -t go_download.XXXXXXXXXX)"
-curl -o target/go.tar.gz -L https://storage.googleapis.com/golang/go1.7.3.darwin-amd64.tar.gz
+
+if [ -f ~/go.tar.gz ] && md5 ~/go.tar.gz | grep -q d69f55f3174d3ee74c9bf7feb917d55f; then
+    cp ~/go.tar.gz target/go.tar.gz
+else
+  curl -o target/go.tar.gz -L https://storage.googleapis.com/golang/go1.7.3.darwin-amd64.tar.gz
+fi
+
 tar -C "${GO_DOWNLOAD_DIR}" -xf target/go.tar.gz
 export GOROOT="${GO_DOWNLOAD_DIR}/go"
 export PATH="${GOROOT}/bin:${PATH}"

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ var (
 		&MountsFeature{},
 	}
 
-	version = "6.0.9"
+	version = "6.1.0alpha1"
 	usage   = `
 generic-worker
 generic-worker is a taskcluster worker that can run on any platform that supports go (golang).

--- a/model.go
+++ b/model.go
@@ -48,6 +48,7 @@ type (
 		RequiredDiskSpaceMegabytes     int                    `json:"requiredDiskSpaceMegabytes"`
 		ShutdownMachineOnInternalError bool                   `json:"shutdownMachineOnInternalError"`
 		NumberOfTasksToRun             uint                   `json:"numberOfTasksToRun"`
+		DeploymentID                   string                 `json:"deploymentId"`
 	}
 
 	// Used for modelling the xml we get back from Azure

--- a/release.sh
+++ b/release.sh
@@ -91,7 +91,7 @@ fi
 # Check that the current HEAD is also the tip of the official repo master
 # branch. If the commits match, it does not matter what the local branch
 # name is, or even if we have a detached head.
-if ! "${NEW_VERSION}" | grep -q "alpha"; then
+if ! echo "${NEW_VERSION}" | grep -q "alpha"; then
   remoteMasterSha="$(git ls-remote "${OFFICIAL_GIT_REPO}" master | cut -f1)"
   localSha="$(git rev-parse HEAD)"
   if [ "${remoteMasterSha}" != "${localSha}" ]; then
@@ -110,12 +110,12 @@ done
 git commit -m "Version bump from ${OLD_VERSION} to ${NEW_VERSION}"
 git tag "v${NEW_VERSION}"
 # only ensure master is updated if it is a non-alpha release
-if ! "${NEW_VERSION}" | grep -q "alpha"; then
+if ! echo "${NEW_VERSION}" | grep -q "alpha"; then
   git push "${OFFICIAL_GIT_REPO}" "+refs/tags/v${NEW_VERSION}:refs/heads/master"
 fi
 git push "${OFFICIAL_GIT_REPO}" "+refs/tags/v${NEW_VERSION}:refs/tags/v${NEW_VERSION}"
 
-if ! "${NEW_VERSION}" | grep -q "alpha"; then
+if ! echo "${NEW_VERSION}" | grep -q "alpha"; then
   echo
   echo 'Will you also be deploying this release to production? If so, please run:'
   echo

--- a/release.sh
+++ b/release.sh
@@ -74,16 +74,19 @@ if [ -n "$modified" ]; then
   exit 68
 fi
 
+# ******** If making a NON-alpha release only **********
 # Check that the current HEAD is also the tip of the official repo master
 # branch. If the commits match, it does not matter what the local branch
 # name is, or even if we have a detached head.
-remoteMasterSha="$(git ls-remote "${OFFICIAL_GIT_REPO}" master | cut -f1)"
-localMasterSha="$(git rev-parse HEAD)"
-if [ "${remoteMasterSha}" != "${localMasterSha}" ]; then
-  echo "Locally, you are on commit ${localMasterSha}."
-  echo "The remote taskcluster repo is on commit ${remoteMasterSha}."
-  echo "Make sure to git push/pull so that they both point to the same commit."
-  exit 69
+if ! "${NEW_VERSION}" | grep -q "alpha"; then
+  remoteMasterSha="$(git ls-remote "${OFFICIAL_GIT_REPO}" master | cut -f1)"
+  localMasterSha="$(git rev-parse HEAD)"
+  if [ "${remoteMasterSha}" != "${localMasterSha}" ]; then
+    echo "Locally, you are on commit ${localMasterSha}."
+    echo "The remote taskcluster repo is on commit ${remoteMasterSha}."
+    echo "Make sure to git push/pull so that they both point to the same commit."
+    exit 69
+  fi
 fi
 
 # Make sure that build environment is clean

--- a/release.sh
+++ b/release.sh
@@ -22,13 +22,16 @@ fi
 
 OLD_VERSION="$(cat main.go | sed -n 's/^[[:space:]]*version = "\(.*\)"$/\1/p')"
 
-if ! echo "${OLD_VERSION}" | grep -q '^[1-9][0-9]*\.\(0\|[1-9][0-9]*\)\.\(0\|[1-9][0-9]*\)$'; then
-  echo "Previous release version '${OLD_VERSION}' not allowed (should be x.y.z where x>=1, y>=0, z>=0 and x,y,z are integers, with no leading zeros) - please fix main.go" >&2
+VALID_FORMAT='^[1-9][0-9]*\.\(0\|[1-9][0-9]*\)\.\(0\|[1-9]\)\([0-9]*alpha[1-9][0-9]*\|[0-9]*\)$'
+FORMAT_EXPLANATION='should be "<a>.<b>.<c>" OR "<a>.<b>.<c>alpha<d>" where a>=1, b>=0, c>=0, d>=1 and a,b,c,d are integers, with no leading zeros'
+
+if ! echo "${OLD_VERSION}" | grep -q "${VALID_FORMAT}"; then
+  echo "Previous release version '${OLD_VERSION}' not allowed (${FORMAT_EXPLANATION}) - please fix main.go" >&2
   exit 64
 fi
 
-if ! echo "${NEW_VERSION}" | grep -q '^[1-9][0-9]*\.\(0\|[1-9][0-9]*\)\.\(0\|[1-9][0-9]*\)$'; then
-  echo "Release version '${NEW_VERSION}' not allowed (should be x.y.z where x>=1, y>=0, z>=0 and x,y,z are integers, with no leading zeros)" >&2
+if ! echo "${NEW_VERSION}" | grep -q "${VALID_FORMAT}"; then
+  echo "Release version '${NEW_VERSION}' not allowed (${FORMAT_EXPLANATION})" >&2
   exit 65
 fi
 

--- a/worker_types/nss-win2012r2/userdata
+++ b/worker_types/nss-win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v6.0.9/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v6.1.0alpha1/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")

--- a/worker_types/win2012r2/userdata
+++ b/worker_types/win2012r2/userdata
@@ -78,7 +78,7 @@ $client.DownloadFile("https://raw.githubusercontent.com/mozilla/build-tooltool/m
 
 # download generic-worker
 md C:\generic-worker
-$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v6.0.9/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+$client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download/v6.1.0alpha1/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 
 # download livelog
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download/v0.0.6/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")


### PR DESCRIPTION
@grenade This is a first stab. Maybe we are lucky and it works first time, but it is complex enough that that might not be the case. It is kind of tricky to test in a unit test as it requires interaction with the provisioner, and I didn't really fancy creating fake worker types in integration tests. So I think the best is for me to make an alpha release, test it in `ami-test-win2012r2` worker type...