### PR TITLE
bug 1307204 - give system time to log exceptions

### DIFF
--- a/plat_windows.go
+++ b/plat_windows.go
@@ -35,7 +35,7 @@ type OSUser struct {
 }
 
 func immediateShutdown() {
-	cmd := exec.Command("C:\\Windows\\System32\\shutdown.exe", "/s")
+	cmd := exec.Command("C:\\Windows\\System32\\shutdown.exe", "/s", "/t", "60")
 	err := cmd.Run()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
c4.4xlarge instances are being terminated by g-w before doing any work. papertrail [logs](https://papertrailapp.com/systems/532378943/events?focus=734832384771678217) contain only the shutdown command initiated by the g-w user and no reason for the halt (eg: "Nov 14 07:02:18 i-06272f1dc5bf6e4e9.gecko-1-b-win2012-beta.euc1.mozilla.com User32:  The process C:\Windows\System32\shutdown.exe (I-06272F1DC5BF6) has initiated the shutdown of computer I-06272F1DC5BF6 on behalf of user I-06272F1DC5BF6\GenericWorker for the following reason: No title for this reason could be found   Reason Code: 0x800000ff   Shutdown Type: shutdown   Comment:  "). by delaying the shutdown, i am hoping to capture the g-w logs before the instance is terminated.