### PR TITLE
Bug 1261188 - set user profile path

### DIFF
--- a/plat_windows.go
+++ b/plat_windows.go
@@ -90,6 +90,7 @@ func prepareTaskUser(userName string) {
 	user := &runtime.OSUser{
 		Name:     userName,
 		Password: generatePassword(),
+		Home:     taskContext.TaskDir,
 	}
 	err := user.CreateNew()
 	if err != nil {

--- a/plat_windows.go
+++ b/plat_windows.go
@@ -86,6 +86,10 @@ func deleteTaskDir(path string) error {
 }
 
 func prepareTaskUser(userName string) {
+	err = os.MkdirAll(taskContext.TaskDir, 0777)
+	if err != nil {
+		panic(err)
+	}
 	// create user
 	user := &runtime.OSUser{
 		Name:     userName,
@@ -106,10 +110,6 @@ func prepareTaskUser(userName string) {
 		LoginInfo:   loginInfo,
 		Desktop:     newDesktop,
 		OrigDesktop: origDesktop,
-	}
-	err = os.MkdirAll(taskContext.TaskDir, 0777)
-	if err != nil {
-		panic(err)
 	}
 	err = RedirectAppData(loginInfo.HUser, filepath.Join(taskContext.TaskDir, "AppData"))
 	if err != nil {

--- a/runtime/runtime_windows.go
+++ b/runtime/runtime_windows.go
@@ -13,6 +13,7 @@ import (
 type OSUser struct {
 	Name     string
 	Password string
+	Home     string
 }
 
 func (user *OSUser) EnsureCreated() error {
@@ -27,7 +28,7 @@ func (user *OSUser) Create(okIfExists bool) error {
 	log.Print("Creating Windows user " + user.Name + "...")
 	userExisted, err := AllowError(
 		"The account already exists",
-		"net", "user", user.Name, user.Password, "/add", "/expires:never", "/passwordchg:no", "/y",
+		"net", "user", user.Name, user.Password, "/add", "/expires:never", "/passwordchg:no", "/y", "/homedir:" + user.Home, "/profilepath:" + user.Home,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
i'm hoping that setting these values at user creation causes the LoadUserProfile system call to create the AppData folder under the task folder rather than under the os default user profile directory when the task directory is in a non-standard location