### PR TITLE
Bug 1352457 - support optional artifact name

### DIFF
--- a/all-unix-style.yml
+++ b/all-unix-style.yml
@@ -60,6 +60,10 @@ properties:
           title: Artifact location
           type: string
           description: Filesystem path of artifact
+        name:
+          title: Name of the artifact
+          type: string
+          description: Name of the artifact, as it will be published. If not set, `path` will be used.
         expires:
           title: Expiry date and time
           type: string

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -162,6 +162,7 @@ func TestDirectoryArtifacts(t *testing.T) {
 			S3Artifact{
 				BaseArtifact: BaseArtifact{
 					CanonicalPath: "SampleArtifacts/%%%/v/X",
+					Name:          "SampleArtifacts/%%%/v/X",
 					Expires:       inAnHour,
 				},
 				MimeType: "application/octet-stream",
@@ -169,6 +170,7 @@ func TestDirectoryArtifacts(t *testing.T) {
 			S3Artifact{
 				BaseArtifact: BaseArtifact{
 					CanonicalPath: "SampleArtifacts/_/X.txt",
+					Name:          "SampleArtifacts/_/X.txt",
 					Expires:       inAnHour,
 				},
 				MimeType: "text/plain; charset=utf-8",
@@ -176,6 +178,7 @@ func TestDirectoryArtifacts(t *testing.T) {
 			S3Artifact{
 				BaseArtifact: BaseArtifact{
 					CanonicalPath: "SampleArtifacts/b/c/d.jpg",
+					Name:          "SampleArtifacts/b/c/d.jpg",
 					Expires:       inAnHour,
 				},
 				MimeType: "image/jpeg",
@@ -206,6 +209,7 @@ func TestMissingFileArtifact(t *testing.T) {
 			ErrorArtifact{
 				BaseArtifact: BaseArtifact{
 					CanonicalPath: "TestMissingFileArtifact/no_such_file",
+					Name:          "TestMissingFileArtifact/no_such_file",
 					Expires:       inAnHour,
 				},
 				Message: "Could not read file '" + filepath.Join(taskContext.TaskDir, "TestMissingFileArtifact", "no_such_file") + "'",
@@ -237,6 +241,7 @@ func TestMissingDirectoryArtifact(t *testing.T) {
 			ErrorArtifact{
 				BaseArtifact: BaseArtifact{
 					CanonicalPath: "TestMissingDirectoryArtifact/no_such_dir",
+					Name:          "TestMissingDirectoryArtifact/no_such_dir",
 					Expires:       inAnHour,
 				},
 				Message: "Could not read directory '" + filepath.Join(taskContext.TaskDir, "TestMissingDirectoryArtifact", "no_such_dir") + "'",
@@ -268,6 +273,7 @@ func TestFileArtifactIsDirectory(t *testing.T) {
 			ErrorArtifact{
 				BaseArtifact: BaseArtifact{
 					CanonicalPath: "SampleArtifacts/b/c",
+					Name:          "SampleArtifacts/b/c",
 					Expires:       inAnHour,
 				},
 				Message: "File artifact '" + filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c") + "' exists as a directory, not a file, on the worker",
@@ -291,6 +297,7 @@ func TestDirectoryArtifactIsFile(t *testing.T) {
 		}{{
 			Expires: inAnHour,
 			Path:    "SampleArtifacts/b/c/d.jpg",
+			Name:    "SampleArtifacts/b/c/d.jpg",
 			Type:    "directory",
 		}},
 

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -306,6 +306,7 @@ func TestDirectoryArtifactIsFile(t *testing.T) {
 			ErrorArtifact{
 				BaseArtifact: BaseArtifact{
 					CanonicalPath: "SampleArtifacts/b/c/d.jpg",
+					Name:          "SampleArtifacts/b/c/d.jpg",
 					Expires:       inAnHour,
 				},
 				Message: "Directory artifact '" + filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg") + "' exists as a file, not a directory, on the worker",

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -32,6 +32,7 @@ func validateArtifacts(
 	t *testing.T,
 	payloadArtifacts []struct {
 		Expires tcclient.Time `json:"expires"`
+		Name    string        `json:"name,omitempty"`
 		Path    string        `json:"path"`
 		Type    string        `json:"type"`
 	},
@@ -53,6 +54,88 @@ func validateArtifacts(
 	}
 }
 
+func TestFileArtifactWithNames(t *testing.T) {
+
+	setup(t)
+	validateArtifacts(t,
+
+		// what appears in task payload
+		[]struct {
+			Expires tcclient.Time `json:"expires"`
+			Name    string        `json:"name,omitempty"`
+			Path    string        `json:"path"`
+			Type    string        `json:"type"`
+		}{
+			{
+				Expires: inAnHour,
+				Path:    "SampleArtifacts/_/X.txt",
+				Type:    "file",
+				Name:    "public/build/firefox.exe",
+			},
+		},
+
+		// what we expect to discover on file system
+		[]Artifact{
+			S3Artifact{
+				BaseArtifact: BaseArtifact{
+					CanonicalPath: "SampleArtifacts/_/X.txt",
+					Name:          "public/build/firefox.exe",
+					Expires:       inAnHour,
+				},
+				MimeType: "text/plain; charset=utf-8",
+			},
+		})
+}
+
+func TestDirectoryArtifactWithNames(t *testing.T) {
+
+	setup(t)
+	validateArtifacts(t,
+
+		// what appears in task payload
+		[]struct {
+			Expires tcclient.Time `json:"expires"`
+			Name    string        `json:"name,omitempty"`
+			Path    string        `json:"path"`
+			Type    string        `json:"type"`
+		}{
+			{
+				Expires: inAnHour,
+				Path:    "SampleArtifacts",
+				Type:    "directory",
+				Name:    "public/b/c",
+			},
+		},
+
+		// what we expect to discover on file system
+		[]Artifact{
+			S3Artifact{
+				BaseArtifact: BaseArtifact{
+					CanonicalPath: "SampleArtifacts/%%%/v/X",
+					Name:          "public/b/c/%%%/v/X",
+					Expires:       inAnHour,
+				},
+				MimeType: "application/octet-stream",
+			},
+			S3Artifact{
+				BaseArtifact: BaseArtifact{
+					CanonicalPath: "SampleArtifacts/_/X.txt",
+					Name:          "public/b/c/_/X.txt",
+					Expires:       inAnHour,
+				},
+				MimeType: "text/plain; charset=utf-8",
+			},
+			S3Artifact{
+				BaseArtifact: BaseArtifact{
+					CanonicalPath: "SampleArtifacts/b/c/d.jpg",
+					Name:          "public/b/c/b/c/d.jpg",
+					Expires:       inAnHour,
+				},
+				MimeType: "image/jpeg",
+			},
+		})
+}
+
 // See the testdata/SampleArtifacts subdirectory of this project. This
 // simulates adding it as a directory artifact in a task payload, and checks
 // that all files underneath this directory are discovered and created as s3
@@ -65,6 +148,7 @@ func TestDirectoryArtifacts(t *testing.T) {
 		// what appears in task payload
 		[]struct {
 			Expires tcclient.Time `json:"expires"`
+			Name    string        `json:"name,omitempty"`
 			Path    string        `json:"path"`
 			Type    string        `json:"type"`
 		}{{
@@ -108,6 +192,7 @@ func TestMissingFileArtifact(t *testing.T) {
 		// what appears in task payload
 		[]struct {
 			Expires tcclient.Time `json:"expires"`
+			Name    string        `json:"name,omitempty"`
 			Path    string        `json:"path"`
 			Type    string        `json:"type"`
 		}{{
@@ -138,6 +223,7 @@ func TestMissingDirectoryArtifact(t *testing.T) {
 		// what appears in task payload
 		[]struct {
 			Expires tcclient.Time `json:"expires"`
+			Name    string        `json:"name,omitempty"`
 			Path    string        `json:"path"`
 			Type    string        `json:"type"`
 		}{{
@@ -168,6 +254,7 @@ func TestFileArtifactIsDirectory(t *testing.T) {
 		// what appears in task payload
 		[]struct {
 			Expires tcclient.Time `json:"expires"`
+			Name    string        `json:"name,omitempty"`
 			Path    string        `json:"path"`
 			Type    string        `json:"type"`
 		}{{
@@ -198,6 +285,7 @@ func TestDirectoryArtifactIsFile(t *testing.T) {
 		// what appears in task payload
 		[]struct {
 			Expires tcclient.Time `json:"expires"`
+			Name    string        `json:"name,omitempty"`
 			Path    string        `json:"path"`
 			Type    string        `json:"type"`
 		}{{
@@ -230,6 +318,7 @@ func TestMissingArtifactFailsTest(t *testing.T) {
 		MaxRunTime: 30,
 		Artifacts: []struct {
 			Expires tcclient.Time `json:"expires"`
+			Name    string        `json:"name,omitempty"`
 			Path    string        `json:"path"`
 			Type    string        `json:"type"`
 		}{
@@ -265,6 +354,7 @@ func TestUpload(t *testing.T) {
 		MaxRunTime: 30,
 		Artifacts: []struct {
 			Expires tcclient.Time `json:"expires"`
+			Name    string        `json:"name,omitempty"`
 			Path    string        `json:"path"`
 			Type    string        `json:"type"`
 		}{

--- a/chain_of_trust.go
+++ b/chain_of_trust.go
@@ -160,7 +160,7 @@ func (cot *ChainOfTrustTaskFeature) Stop() *CommandExecutionError {
 }
 
 func calculateHash(artifact S3Artifact) (hash string, err error) {
-	rawContentFile := filepath.Join(taskContext.TaskDir, artifact.Base().CanonicalPath)
+	rawContentFile := filepath.Join(taskContext.TaskDir, artifact.CanonicalPath)
 	rawContent, err := os.Open(rawContentFile)
 	if err != nil {
 		return

--- a/generated_all-unix-style.go
+++ b/generated_all-unix-style.go
@@ -43,6 +43,9 @@ type (
 			// Date when artifact should expire must be in the future
 			Expires tcclient.Time `json:"expires"`
 
+			// Name of the artifact, as it will be published. If not set, `path` will be used.
+			Name string `json:"name,omitempty"`
+
 			// Filesystem path of artifact
 			Path string `json:"path"`
 
@@ -356,6 +359,11 @@ func taskPayloadSchema() string {
             "description": "Date when artifact should expire must be in the future",
             "format": "date-time",
             "title": "Expiry date and time",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.",
+            "title": "Name of the artifact",
             "type": "string"
           },
           "path": {

--- a/generated_windows.go
+++ b/generated_windows.go
@@ -42,6 +42,9 @@ type (
 			// Date when artifact should expire must be in the future
 			Expires tcclient.Time `json:"expires"`
 
+			// Name of the artifact, as it will be published. If not set, `path` will be used.
+			Name string `json:"name,omitempty"`
+
 			// Filesystem path of artifact
 			Path string `json:"path"`
 
@@ -356,6 +359,11 @@ func taskPayloadSchema() string {
             "description": "Date when artifact should expire must be in the future",
             "format": "date-time",
             "title": "Expiry date and time",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.",
+            "title": "Name of the artifact",
             "type": "string"
           },
           "path": {

--- a/livelog.go
+++ b/livelog.go
@@ -89,6 +89,7 @@ func (l *LiveLogTask) Stop() *CommandExecutionError {
 		RedirectArtifact{
 			BaseArtifact: BaseArtifact{
 				CanonicalPath: "public/logs/live.log",
+				Name:          "public/logs/live.log",
 				// same expiry as underlying log it points to
 				Expires: l.task.Definition.Expires,
 			},
@@ -120,6 +121,7 @@ func (l *LiveLogTask) uploadLiveLog() error {
 		RedirectArtifact{
 			BaseArtifact: BaseArtifact{
 				CanonicalPath: "public/logs/live.log",
+				Name:          "public/logs/live.log",
 				// livelog expires when task must have completed
 				Expires: tcclient.Time(maxRunTimeDeadline),
 			},

--- a/taskstatus_test.go
+++ b/taskstatus_test.go
@@ -16,6 +16,7 @@ func TestResolveResolvedTask(t *testing.T) {
 		MaxRunTime: 60,
 		Artifacts: []struct {
 			Expires tcclient.Time `json:"expires"`
+			Name    string        `json:"name,omitempty"`
 			Path    string        `json:"path"`
 			Type    string        `json:"type"`
 		}{

--- a/windows.yml
+++ b/windows.yml
@@ -58,6 +58,10 @@ properties:
           title: Artifact location
           type: string
           description: Filesystem path of artifact
+        name:
+          title: Name of the artifact
+          type: string
+          description: Name of the artifact, as it will be published. If not set, `path` will be used.
         expires:
           title: Expiry date and time
           type: string


### PR DESCRIPTION
@grenade Feel free to take a look at this too and give feedback! I can't assign you as a reviewer as it looks like you're not a member of the repo - I can look at fixing that too.

Note this fix allows you to specify an optional artifact name, which if not specified, defaults to the artifact path, in order to maintain backwards compatibility.

This is needed for the OS X rollout, since the symlink trick doesn't work on OS X as it does on Windows.