### PR TITLE
Ignore configuration file created by generic-worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ coverage.report
 # For any releases made locally
 /target/
 worker_type_definitions
+
+# Files created by generic-worker when run for the first time
+generic-worker.config


### PR DESCRIPTION
The first time running `generic-worker run` a configuration file is created which should not be checked in.