### PR TITLE
Bug 1356800 - avoid nil pointer exception when uploading artifacts

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -326,6 +326,9 @@ tasks:
   #################### Linux ARM6 build ####################
   ##########################################################
 
+  ############ Currently not using Raspberry PI ############
+  ############    --- therefore disabled ---    ############
+
   # - provisionerId: pmoore-manual
   #   workerType: raspberry-pi-3b
   #   metadata:

--- a/artifacts.go
+++ b/artifacts.go
@@ -175,14 +175,16 @@ func (artifact S3Artifact) ProcessResponse(resp interface{}) (err error) {
 		return putResp, err, nil
 	}
 	putResp, putAttempts, err := httpbackoff.Retry(httpCall)
-	defer putResp.Body.Close()
 	log.Printf("%v put requests issued to %v", putAttempts, response.PutURL)
-	respBody, dumpError := httputil.DumpResponse(putResp, true)
-	if dumpError != nil {
-		log.Print("Could not dump response output, never mind...")
-	} else {
-		log.Print("Response")
-		log.Print(string(respBody))
+	if putResp != nil {
+		defer putResp.Body.Close()
+		respBody, dumpError := httputil.DumpResponse(putResp, true)
+		if dumpError != nil {
+			log.Print("Could not dump response output, never mind...")
+		} else {
+			log.Print("Response")
+			log.Print(string(respBody))
+		}
 	}
 	return err
 }


### PR DESCRIPTION
This was causing some crashes, such as [this log extract](https://papertrailapp.com/systems/812287681/events):

```
Apr 15 16:09:29 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 2017/04/15 14:09:27 Resolving task... 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 2017/04/15 14:09:28 goroutine 1 [running]: 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: runtime/debug.Stack(0x0, 0x0, 0x0) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/go/src/runtime/debug/stack.go:24 +0x80 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.RunWorker.func1() 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:444 +0x43 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: panic(0x8c7640, 0x12042030) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/go/src/runtime/panic.go:458 +0x40b 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.(*TaskRun).Run.func1(0x12209528, 0x121bc000) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:1064 +0x162 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: panic(0x8c7640, 0x12042030) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/go/src/runtime/panic.go:458 +0x40b 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.(*TaskRun).Run.func3(0x12209528, 0x121bc000, 0xb2dd90, 0x123b8718) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:1096 +0x1c7 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: panic(0x8c7640, 0x12042030) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/go/src/runtime/panic.go:458 +0x40b 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.S3Artifact.ProcessResponse(0x123d00a0, 0x11, 0x123d00e0, 0x18, 0xd0966f94, 0xe, 0xbc77508, 0xb4be40, 0x929aec, 0xa, ...) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/artifacts.go:178 +0x605 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.(*S3Artifact).ProcessResponse(0x121e2750, 0x882160, 0x123dacc0, 0x0, 0x0) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	<autogenerated>:13 +0x9f 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.(*TaskRun).uploadArtifact(0x121bc000, 0xb2f940, 0x121e2750, 0x0) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/artifacts.go:391 +0xaa9 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.(*TaskRun).Run.func5(0x121bc000, 0x12209528) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:1153 +0xf0 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.(*TaskRun).Run(0x121bc000, 0x0) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:1192 +0xcc6 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.FindAndRunTask(0x3b9aca00) 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:568 +0x2a9 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.RunWorker() 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:487 +0x7a9 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: main.main() 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 	/home/travis/gopath/src/github.com/taskcluster/generic-worker/main.go:307 +0x648 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 2017/04/15 14:09:28  *********** PANIC occurred! ***********  
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 2017/04/15 14:09:28 Exiting worker and shutting down computer... 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 2017/04/15 14:09:28 runtime error: invalid memory address or nil pointer dereference 
Apr 15 16:09:30 i-04638966ed4f61a5f.gecko-t-win7-32.use1.mozilla.com generic-worker: 2017/04/15 14:09:28 Immediate shutdown being issued... 
```

which occurred in [this task run](https://tools.taskcluster.net/task-inspector/#aSv8B3S7SaaxuYlBMfPHOA/0). Since the task failed, the task had already been deemed as a failure by the time the exception occured, the task was (intentionally and correctly) resolved as a failure rather than an exception, however after the task was resolved, the worker self-terminated.

The root cause of the above failure was that after the task had failed, one of the task payload artifacts continued to grow in size during the upload process (perhaps a forked process was continuing to write to it) - however, the root cause of that needs to be solved elsewhere - it resulted in the more general issue that a nil pointer exception can occur, which this PR fixes.