### PR TITLE
Bug 1347956 - gzip more artifacts

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -73,8 +73,7 @@ tasks:
           source ~/env_private.sh
           go get -d "github.com/taskcluster/generic-worker"
           cd "${GOPATH}/src/github.com/taskcluster/generic-worker"
-          git remote add '{{ event.head.user.login }}' '{{ event.head.repo.url }}'
-          git fetch --tags '{{ event.head.user.login }}'
+          git fetch '{{ event.head.repo.url }}' "+refs/*:refs/tasks/${TASK_ID}/*"
           git checkout '{{ event.head.sha }}'
           go get github.com/taskcluster/livelog github.com/gordonklaus/ineffassign
           cd gw-codegen
@@ -119,8 +118,7 @@ tasks:
         - git config --global core.autocrlf false
         - 'go get -d "github.com/taskcluster/generic-worker"'
         - 'cd "gopath\src\github.com\taskcluster\generic-worker"'
-        - 'git remote add "{{ event.head.user.login }}" "{{ event.head.repo.url }}"'
-        - 'git fetch --tags "{{ event.head.user.login }}"'
+        - 'git fetch "{{ event.head.repo.url }}" "+refs/*:refs/tasks/%TASK_ID%/*"'
         - git checkout {{ event.head.sha }}
         - go get github.com/taskcluster/livelog github.com/gordonklaus/ineffassign
         - cd gw-codegen
@@ -186,8 +184,7 @@ tasks:
         - git config --global core.autocrlf false
         - go get -d "github.com/taskcluster/generic-worker"
         - 'cd "gopath\src\github.com\taskcluster\generic-worker"'
-        - 'git remote add "{{ event.head.user.login }}" "{{ event.head.repo.url }}"'
-        - 'git fetch --tags "{{ event.head.user.login }}"'
+        - 'git fetch "{{ event.head.repo.url }}" "+refs/*:refs/tasks/%TASK_ID%/*"'
         - git checkout {{ event.head.sha }}
         - go get github.com/taskcluster/livelog github.com/gordonklaus/ineffassign
         - cd gw-codegen
@@ -253,8 +250,7 @@ tasks:
         - git config --global core.autocrlf false
         - go get -d "github.com/taskcluster/generic-worker"
         - 'cd "gopath\src\github.com\taskcluster\generic-worker"'
-        - 'git remote add "{{ event.head.user.login }}" "{{ event.head.repo.url }}"'
-        - 'git fetch --tags "{{ event.head.user.login }}"'
+        - 'git fetch "{{ event.head.repo.url }}" "+refs/*:refs/tasks/%TASK_ID%/*"'
         - git checkout {{ event.head.sha }}
         - go get github.com/taskcluster/livelog github.com/gordonklaus/ineffassign
         - cd gw-codegen
@@ -328,8 +324,7 @@ tasks:
             cd "${GOPATH}/src/github.com/taskcluster"
             if [ ! -d generic-worker/.git ]; then rm -rf generic-worker; git clone '{{ event.head.repo.url }}' 'generic-worker'; fi
             cd 'generic-worker'
-            if [ ! -d '.git/refs/remotes/{{ event.head.user.login }}' ]; then git remote add '{{ event.head.user.login }}' '{{ event.head.repo.url }}'; fi
-            git fetch --tags '{{ event.head.user.login }}'
+            git fetch '{{ event.head.repo.url }}' "+refs/*:refs/tasks/${TASK_ID}/*"
             git checkout -f '{{ event.head.sha }}'
             git clean -fdx
             go get -u github.com/taskcluster/livelog github.com/gordonklaus/ineffassign
@@ -393,8 +388,7 @@ tasks:
   #           cd "${GOPATH}/src/github.com/taskcluster"
   #           if [ ! -d generic-worker/.git ]; then rm -rf generic-worker; git clone '{{ event.head.repo.url }}' 'generic-worker'; fi
   #           cd 'generic-worker'
-  #           if [ ! -d '.git/refs/remotes/{{ event.head.user.login }}' ]; then git remote add '{{ event.head.user.login }}' '{{ event.head.repo.url }}'; fi
-  #           git fetch --tags '{{ event.head.user.login }}'
+  #           git fetch '{{ event.head.repo.url }}' "+refs/*:refs/tasks/${TASK_ID}/*"
   #           git checkout -f '{{ event.head.sha }}'
   #           git clean -fdx
   #           go get -u github.com/taskcluster/livelog github.com/gordonklaus/ineffassign

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # generic-worker
-<img src="https://tools.taskcluster.net/lib/assets/taskcluster-120.png" />
+
+[![logo](https://tools.taskcluster.net/lib/assets/taskcluster-120.png)](https://tools.taskcluster.net/lib/assets/taskcluster-120.png)
+
 [![Linux Build Status](https://img.shields.io/travis/taskcluster/generic-worker.svg?style=flat-square&label=linux+build)](https://travis-ci.org/taskcluster/generic-worker)
 [![Windows Build Status](https://img.shields.io/appveyor/ci/petemoore/generic-worker.svg?style=flat-square&label=windows+build)](https://ci.appveyor.com/project/petemoore/generic-worker)
 [![GoDoc](https://godoc.org/github.com/taskcluster/generic-worker?status.svg)](https://godoc.org/github.com/taskcluster/generic-worker)

--- a/artifacts.go
+++ b/artifacts.go
@@ -35,7 +35,7 @@ type (
 		ProcessResponse(response interface{}) error
 		RequestObject() interface{}
 		ResponseObject() interface{}
-		Base() BaseArtifact
+		Base() *BaseArtifact
 	}
 
 	BaseArtifact struct {
@@ -45,39 +45,39 @@ type (
 	}
 
 	S3Artifact struct {
-		BaseArtifact
+		*BaseArtifact
 		MimeType        string
 		ContentEncoding string
 	}
 
 	AzureArtifact struct {
-		BaseArtifact
+		*BaseArtifact
 		MimeType string
 	}
 
 	RedirectArtifact struct {
-		BaseArtifact
+		*BaseArtifact
 		MimeType string
 		URL      string
 	}
 
 	ErrorArtifact struct {
-		BaseArtifact
+		*BaseArtifact
 		Message string
 		Reason  string
 	}
 )
 
-func (base BaseArtifact) Base() BaseArtifact {
+func (base *BaseArtifact) Base() *BaseArtifact {
 	return base
 }
 
-func (artifact RedirectArtifact) ProcessResponse(response interface{}) error {
+func (artifact *RedirectArtifact) ProcessResponse(response interface{}) error {
 	// nothing to do
 	return nil
 }
 
-func (redirectArtifact RedirectArtifact) RequestObject() interface{} {
+func (redirectArtifact *RedirectArtifact) RequestObject() interface{} {
 	return &queue.RedirectArtifactRequest{
 		ContentType: redirectArtifact.MimeType,
 		Expires:     redirectArtifact.Expires,
@@ -86,16 +86,16 @@ func (redirectArtifact RedirectArtifact) RequestObject() interface{} {
 	}
 }
 
-func (redirectArtifact RedirectArtifact) ResponseObject() interface{} {
+func (redirectArtifact *RedirectArtifact) ResponseObject() interface{} {
 	return new(queue.RedirectArtifactResponse)
 }
 
-func (artifact ErrorArtifact) ProcessResponse(response interface{}) error {
+func (artifact *ErrorArtifact) ProcessResponse(response interface{}) error {
 	// TODO: process error response
 	return nil
 }
 
-func (errArtifact ErrorArtifact) RequestObject() interface{} {
+func (errArtifact *ErrorArtifact) RequestObject() interface{} {
 	return &queue.ErrorArtifactRequest{
 		Expires:     errArtifact.Expires,
 		Message:     errArtifact.Message,
@@ -104,42 +104,51 @@ func (errArtifact ErrorArtifact) RequestObject() interface{} {
 	}
 }
 
-func (errArtifact ErrorArtifact) ResponseObject() interface{} {
+func (errArtifact *ErrorArtifact) ResponseObject() interface{} {
 	return new(queue.ErrorArtifactResponse)
 }
 
-// gzipCompressFile gzip-compresses the file at path rawContentFile and writes
+func (errArtifact *ErrorArtifact) String() string {
+	return fmt.Sprintf("%q", *errArtifact)
+}
+
+// createTempFileForPUTBody gzip-compresses the file at path rawContentFile and writes
 // it to a temporary file. The file path of the generated temporary file is returned.
 // It is the responsibility of the caller to delete the temporary file.
-func gzipCompressFile(rawContentFile string) string {
+func (artifact *S3Artifact) CreateTempFileForPUTBody() string {
+	rawContentFile := filepath.Join(taskContext.TaskDir, artifact.CanonicalPath)
 	baseName := filepath.Base(rawContentFile)
 	tmpFile, err := ioutil.TempFile("", baseName)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer tmpFile.Close()
-	gzipLogWriter := gzip.NewWriter(tmpFile)
-	gzipLogWriter.Name = baseName
-	rawContent, err := os.Open(rawContentFile)
+	var target io.Writer = tmpFile
+	if artifact.ContentEncoding == "gzip" {
+		gzipLogWriter := gzip.NewWriter(tmpFile)
+		defer gzipLogWriter.Close()
+		gzipLogWriter.Name = baseName
+		target = gzipLogWriter
+	}
+	source, err := os.Open(rawContentFile)
 	if err != nil {
 		panic(err)
 	}
-	defer rawContent.Close()
-	io.Copy(gzipLogWriter, rawContent)
-	gzipLogWriter.Close()
+	defer source.Close()
+	io.Copy(target, source)
 	return tmpFile.Name()
 }
 
-func (artifact S3Artifact) ProcessResponse(resp interface{}) (err error) {
-	response := resp.(*queue.S3ArtifactResponse)
-	rawContentFile := filepath.Join(taskContext.TaskDir, artifact.CanonicalPath)
+func (artifact *S3Artifact) ChooseContentEncoding() {
+	artifact.ContentEncoding = "gzip"
+}
 
-	// if Content-Encoding is gzip then we will need to gzip content...
-	transferContentFile := rawContentFile
-	if artifact.ContentEncoding == "gzip" {
-		transferContentFile = gzipCompressFile(rawContentFile)
-		defer os.Remove(transferContentFile)
-	}
+func (artifact *S3Artifact) ProcessResponse(resp interface{}) (err error) {
+	response := resp.(*queue.S3ArtifactResponse)
+
+	artifact.ChooseContentEncoding()
+	transferContentFile := artifact.CreateTempFileForPUTBody()
+	defer os.Remove(transferContentFile)
 
 	// perform http PUT to upload to S3...
 	httpClient := &http.Client{}
@@ -189,7 +198,7 @@ func (artifact S3Artifact) ProcessResponse(resp interface{}) (err error) {
 	return err
 }
 
-func (s3Artifact S3Artifact) RequestObject() interface{} {
+func (s3Artifact *S3Artifact) RequestObject() interface{} {
 	return &queue.S3ArtifactRequest{
 		ContentType: s3Artifact.MimeType,
 		Expires:     s3Artifact.Expires,
@@ -197,8 +206,12 @@ func (s3Artifact S3Artifact) RequestObject() interface{} {
 	}
 }
 
-func (s3Artifact S3Artifact) ResponseObject() interface{} {
+func (s3Artifact *S3Artifact) ResponseObject() interface{} {
 	return new(queue.S3ArtifactResponse)
+}
+
+func (s3Artifact *S3Artifact) String() string {
+	return fmt.Sprintf("%q", *s3Artifact)
 }
 
 // Returns the artifacts as listed in the payload of the task (note this does
@@ -206,7 +219,7 @@ func (s3Artifact S3Artifact) ResponseObject() interface{} {
 func (task *TaskRun) PayloadArtifacts() []Artifact {
 	artifacts := make([]Artifact, 0)
 	for _, artifact := range task.Payload.Artifacts {
-		base := BaseArtifact{
+		base := &BaseArtifact{
 			CanonicalPath: canonicalPath(artifact.Path),
 			Name:          artifact.Name,
 			Expires:       artifact.Expires,
@@ -238,7 +251,7 @@ func (task *TaskRun) PayloadArtifacts() []Artifact {
 					panic(err)
 				}
 				subName := filepath.Join(base.Name, relativePath)
-				b := BaseArtifact{
+				b := &BaseArtifact{
 					CanonicalPath: canonicalPath(subPath),
 					Name:          canonicalPath(subName),
 					Expires:       artifact.Expires,
@@ -268,12 +281,12 @@ func (task *TaskRun) PayloadArtifacts() []Artifact {
 // ErrorArtifact, otherwise if it exists as a file, as
 // "invalid-resource-on-worker" ErrorArtifact
 // TODO: need to also handle "too-large-file-on-worker"
-func resolve(base BaseArtifact, artifactType string) Artifact {
+func resolve(base *BaseArtifact, artifactType string) Artifact {
 	fullPath := filepath.Join(taskContext.TaskDir, base.CanonicalPath)
 	fileReader, err := os.Open(fullPath)
 	if err != nil {
 		// cannot read file/dir, create an error artifact
-		return ErrorArtifact{
+		return &ErrorArtifact{
 			BaseArtifact: base,
 			Message:      fmt.Sprintf("Could not read %s '%s'", artifactType, fullPath),
 			Reason:       "file-missing-on-worker",
@@ -283,21 +296,21 @@ func resolve(base BaseArtifact, artifactType string) Artifact {
 	// ok it exists, but is it right type?
 	fileinfo, err := fileReader.Stat()
 	if err != nil {
-		return ErrorArtifact{
+		return &ErrorArtifact{
 			BaseArtifact: base,
 			Message:      fmt.Sprintf("Could not stat %s '%s'", artifactType, fullPath),
 			Reason:       "invalid-resource-on-worker",
 		}
 	}
 	if artifactType == "file" && fileinfo.IsDir() {
-		return ErrorArtifact{
+		return &ErrorArtifact{
 			BaseArtifact: base,
 			Message:      fmt.Sprintf("File artifact '%s' exists as a directory, not a file, on the worker", fullPath),
 			Reason:       "invalid-resource-on-worker",
 		}
 	}
 	if artifactType == "directory" && !fileinfo.IsDir() {
-		return ErrorArtifact{
+		return &ErrorArtifact{
 			BaseArtifact: base,
 			Message:      fmt.Sprintf("Directory artifact '%s' exists as a file, not a directory, on the worker", fullPath),
 			Reason:       "invalid-resource-on-worker",
@@ -318,7 +331,7 @@ func resolve(base BaseArtifact, artifactType string) Artifact {
 		// application/octet-stream is the mime type for "unknown"
 		mimeType = "application/octet-stream"
 	}
-	return S3Artifact{
+	return &S3Artifact{
 		BaseArtifact: base,
 		MimeType:     mimeType,
 	}
@@ -335,8 +348,8 @@ func canonicalPath(path string) string {
 
 func (task *TaskRun) uploadLog(logFile string) *CommandExecutionError {
 	return task.uploadArtifact(
-		S3Artifact{
-			BaseArtifact: BaseArtifact{
+		&S3Artifact{
+			BaseArtifact: &BaseArtifact{
 				CanonicalPath: logFile,
 				Name:          logFile,
 				// logs expire when task expires

--- a/artifacts.go
+++ b/artifacts.go
@@ -140,6 +140,35 @@ func (artifact *S3Artifact) CreateTempFileForPUTBody() string {
 }
 
 func (artifact *S3Artifact) ChooseContentEncoding() {
+	// respect value, if already set
+	if artifact.ContentEncoding != "" {
+		return
+	}
+	// based on https://github.com/evansd/whitenoise/blob/03f6ea846394e01cbfe0c730141b81eb8dd6e88a/whitenoise/compress.py#L21-L29
+	SKIP_COMPRESS_EXTENSIONS := map[string]bool{
+		// Images
+		".jpg":  true,
+		".jpeg": true,
+		".png":  true,
+		".gif":  true,
+		".webp": true,
+		// Compressed files
+		".zip": true,
+		".gz":  true,
+		".tgz": true,
+		".bz2": true,
+		".tbz": true,
+		// Flash
+		".swf": true,
+		".flv": true,
+		// Fonts
+		".woff":  true,
+		".woff2": true,
+	}
+	if SKIP_COMPRESS_EXTENSIONS[filepath.Ext(artifact.CanonicalPath)] {
+		return
+	}
+
 	artifact.ContentEncoding = "gzip"
 }
 

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -76,8 +76,8 @@ func TestFileArtifactWithNames(t *testing.T) {
 
 		// what we expect to discover on file system
 		[]Artifact{
-			S3Artifact{
-				BaseArtifact: BaseArtifact{
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "SampleArtifacts/_/X.txt",
 					Name:          "public/build/firefox.exe",
 					Expires:       inAnHour,
@@ -109,24 +109,24 @@ func TestDirectoryArtifactWithNames(t *testing.T) {
 
 		// what we expect to discover on file system
 		[]Artifact{
-			S3Artifact{
-				BaseArtifact: BaseArtifact{
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "SampleArtifacts/%%%/v/X",
 					Name:          "public/b/c/%%%/v/X",
 					Expires:       inAnHour,
 				},
 				MimeType: "application/octet-stream",
 			},
-			S3Artifact{
-				BaseArtifact: BaseArtifact{
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "SampleArtifacts/_/X.txt",
 					Name:          "public/b/c/_/X.txt",
 					Expires:       inAnHour,
 				},
 				MimeType: "text/plain; charset=utf-8",
 			},
-			S3Artifact{
-				BaseArtifact: BaseArtifact{
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "SampleArtifacts/b/c/d.jpg",
 					Name:          "public/b/c/b/c/d.jpg",
 					Expires:       inAnHour,
@@ -159,24 +159,24 @@ func TestDirectoryArtifacts(t *testing.T) {
 
 		// what we expect to discover on file system
 		[]Artifact{
-			S3Artifact{
-				BaseArtifact: BaseArtifact{
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "SampleArtifacts/%%%/v/X",
 					Name:          "SampleArtifacts/%%%/v/X",
 					Expires:       inAnHour,
 				},
 				MimeType: "application/octet-stream",
 			},
-			S3Artifact{
-				BaseArtifact: BaseArtifact{
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "SampleArtifacts/_/X.txt",
 					Name:          "SampleArtifacts/_/X.txt",
 					Expires:       inAnHour,
 				},
 				MimeType: "text/plain; charset=utf-8",
 			},
-			S3Artifact{
-				BaseArtifact: BaseArtifact{
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "SampleArtifacts/b/c/d.jpg",
 					Name:          "SampleArtifacts/b/c/d.jpg",
 					Expires:       inAnHour,
@@ -206,8 +206,8 @@ func TestMissingFileArtifact(t *testing.T) {
 
 		// what we expect to discover on file system
 		[]Artifact{
-			ErrorArtifact{
-				BaseArtifact: BaseArtifact{
+			&ErrorArtifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "TestMissingFileArtifact/no_such_file",
 					Name:          "TestMissingFileArtifact/no_such_file",
 					Expires:       inAnHour,
@@ -238,8 +238,8 @@ func TestMissingDirectoryArtifact(t *testing.T) {
 
 		// what we expect to discover on file system
 		[]Artifact{
-			ErrorArtifact{
-				BaseArtifact: BaseArtifact{
+			&ErrorArtifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "TestMissingDirectoryArtifact/no_such_dir",
 					Name:          "TestMissingDirectoryArtifact/no_such_dir",
 					Expires:       inAnHour,
@@ -270,8 +270,8 @@ func TestFileArtifactIsDirectory(t *testing.T) {
 
 		// what we expect to discover on file system
 		[]Artifact{
-			ErrorArtifact{
-				BaseArtifact: BaseArtifact{
+			&ErrorArtifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "SampleArtifacts/b/c",
 					Name:          "SampleArtifacts/b/c",
 					Expires:       inAnHour,
@@ -303,8 +303,8 @@ func TestDirectoryArtifactIsFile(t *testing.T) {
 
 		// what we expect to discover on file system
 		[]Artifact{
-			ErrorArtifact{
-				BaseArtifact: BaseArtifact{
+			&ErrorArtifact{
+				BaseArtifact: &BaseArtifact{
 					CanonicalPath: "SampleArtifacts/b/c/d.jpg",
 					Name:          "SampleArtifacts/b/c/d.jpg",
 					Expires:       inAnHour,
@@ -433,7 +433,7 @@ func TestUpload(t *testing.T) {
 			extracts: []string{
 				"test artifact",
 			},
-			contentEncoding: "",
+			contentEncoding: "gzip",
 			expires:         payload.Artifacts[0].Expires,
 		},
 	}

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -357,8 +357,12 @@ func TestUpload(t *testing.T) {
 
 	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
 
+	command := helloGoodbye()
+	command = append(command, copyArtifact("SampleArtifacts/_/X.txt")...)
+	command = append(command, copyArtifact("SampleArtifacts/b/c/d.jpg")...)
+
 	payload := GenericWorkerPayload{
-		Command:    append(helloGoodbye(), copyArtifact("SampleArtifacts/_/X.txt")...),
+		Command:    command,
 		MaxRunTime: 30,
 		Artifacts: []struct {
 			Expires tcclient.Time `json:"expires"`
@@ -368,6 +372,11 @@ func TestUpload(t *testing.T) {
 		}{
 			{
 				Path:    "SampleArtifacts/_/X.txt",
+				Expires: expires,
+				Type:    "file",
+			},
+			{
+				Path:    "SampleArtifacts/b/c/d.jpg",
 				Expires: expires,
 				Type:    "file",
 			},
@@ -387,6 +396,7 @@ func TestUpload(t *testing.T) {
 	// some required substrings - not all, just a selection
 	expectedArtifacts := map[string]struct {
 		extracts        []string
+		contentType     string
 		contentEncoding string
 		expires         tcclient.Time
 	}{
@@ -396,6 +406,7 @@ func TestUpload(t *testing.T) {
 				"goodbye world!",
 				`"instance-type": "p3.enormous"`,
 			},
+			contentType:     "text/plain; charset=utf-8",
 			contentEncoding: "gzip",
 			expires:         td.Expires,
 		},
@@ -406,6 +417,7 @@ func TestUpload(t *testing.T) {
 				"=== Task Finished ===",
 				"Exit Code: 0",
 			},
+			contentType:     "text/plain; charset=utf-8",
 			contentEncoding: "gzip",
 			expires:         td.Expires,
 		},
@@ -416,6 +428,7 @@ func TestUpload(t *testing.T) {
 				"=== Task Finished ===",
 				"Exit Code: 0",
 			},
+			contentType:     "text/plain; charset=utf-8",
 			contentEncoding: "gzip",
 			expires:         td.Expires,
 		},
@@ -426,6 +439,7 @@ func TestUpload(t *testing.T) {
 			extracts: []string{
 				"8308d593eb56527137532595a60255a3fcfbe4b6b068e29b22d99742bad80f6f",
 			},
+			contentType:     "text/plain; charset=utf-8",
 			contentEncoding: "gzip",
 			expires:         td.Expires,
 		},
@@ -433,7 +447,14 @@ func TestUpload(t *testing.T) {
 			extracts: []string{
 				"test artifact",
 			},
+			contentType:     "text/plain; charset=utf-8",
 			contentEncoding: "gzip",
+			expires:         payload.Artifacts[0].Expires,
+		},
+		"SampleArtifacts/b/c/d.jpg": {
+			extracts:        []string{},
+			contentType:     "image/jpeg",
+			contentEncoding: "", // jpg files are blacklisted against gzip compression
 			expires:         payload.Artifacts[0].Expires,
 		},
 	}
@@ -457,8 +478,8 @@ func TestUpload(t *testing.T) {
 
 	for artifact := range expectedArtifacts {
 		if a, ok := actualArtifacts[artifact]; ok {
-			if a.ContentType != "text/plain; charset=utf-8" {
-				t.Errorf("Artifact %s should have mime type 'text/plain; charset=utf-8' but has '%s'", artifact, a.ContentType)
+			if a.ContentType != expectedArtifacts[artifact].contentType {
+				t.Errorf("Artifact %s should have mime type '%v' but has '%s'", artifact, expectedArtifacts[artifact].contentType, a.ContentType)
 			}
 			if a.Expires.String() != expectedArtifacts[artifact].expires.String() {
 				t.Errorf("Artifact %s should have expiry '%s' but has '%s'", artifact, expires, a.Expires)
@@ -504,8 +525,8 @@ func TestUpload(t *testing.T) {
 		if actualContentEncoding := rawResp.Header.Get("Content-Encoding"); actualContentEncoding != content.contentEncoding {
 			t.Fatalf("Expected Content-Encoding %q but got Content-Encoding %q for artifact %q from url %v", content.contentEncoding, actualContentEncoding, artifact, url)
 		}
-		if actualContentType := resp.Header.Get("Content-Type"); actualContentType != "text/plain; charset=utf-8" {
-			t.Fatalf("Content-Type in Signed URL response does not match Content-Type of artifact")
+		if actualContentType := resp.Header.Get("Content-Type"); actualContentType != content.contentType {
+			t.Fatalf("Content-Type in Signed URL %v response (%v) does not match Content-Type of artifact (%v)", url, actualContentType, content.contentType)
 		}
 		// check openpgp signature is valid
 		if artifact == "public/logs/chainOfTrust.json.asc" {
@@ -561,8 +582,8 @@ func TestUpload(t *testing.T) {
 	if !reflect.DeepEqual(cotCertTaskRequest, td) {
 		t.Fatalf("Did not get back expected task definition in chain of trust certificate:\n%#v\n ** vs **\n%#v", cotCertTaskRequest, td)
 	}
-	if len(cotCert.Artifacts) != 2 {
-		t.Fatalf("Expected 2 artifact hashes to be listed")
+	if len(cotCert.Artifacts) != 3 {
+		t.Fatalf("Expected 3 artifact hashes to be listed, but found %v", len(cotCert.Artifacts))
 	}
 	if cotCert.TaskID != taskID {
 		t.Fatalf("Expected taskId to be %q but was %q", taskID, cotCert.TaskID)

--- a/chain_of_trust.go
+++ b/chain_of_trust.go
@@ -88,7 +88,7 @@ func (cot *ChainOfTrustTaskFeature) Stop() *CommandExecutionError {
 	artifactHashes := map[string]ArtifactHash{}
 	for _, artifact := range cot.task.Artifacts {
 		switch a := artifact.(type) {
-		case S3Artifact:
+		case *S3Artifact:
 			// make sure SHA256 is calculated
 			hash, err := calculateHash(a)
 			if err != nil {
@@ -159,7 +159,7 @@ func (cot *ChainOfTrustTaskFeature) Stop() *CommandExecutionError {
 	return nil
 }
 
-func calculateHash(artifact S3Artifact) (hash string, err error) {
+func calculateHash(artifact *S3Artifact) (hash string, err error) {
 	rawContentFile := filepath.Join(taskContext.TaskDir, artifact.CanonicalPath)
 	rawContent, err := os.Open(rawContentFile)
 	if err != nil {

--- a/livelog.go
+++ b/livelog.go
@@ -86,8 +86,8 @@ func (l *LiveLogTask) Stop() *CommandExecutionError {
 	log.Print("Redirecting live.log to live_backing.log")
 	logURL := fmt.Sprintf("%v/task/%v/runs/%v/artifacts/%v", Queue.BaseURL, l.task.TaskID, l.task.RunID, "public/logs/live_backing.log")
 	err := l.task.uploadArtifact(
-		RedirectArtifact{
-			BaseArtifact: BaseArtifact{
+		&RedirectArtifact{
+			BaseArtifact: &BaseArtifact{
 				CanonicalPath: "public/logs/live.log",
 				Name:          "public/logs/live.log",
 				// same expiry as underlying log it points to
@@ -118,8 +118,8 @@ func (l *LiveLogTask) uploadLiveLog() error {
 	}
 	getURL.Host = statelessHostname + ":" + strconv.Itoa(int(l.liveLog.GETPort))
 	uploadErr := l.task.uploadArtifact(
-		RedirectArtifact{
-			BaseArtifact: BaseArtifact{
+		&RedirectArtifact{
+			BaseArtifact: &BaseArtifact{
 				CanonicalPath: "public/logs/live.log",
 				Name:          "public/logs/live.log",
 				// livelog expires when task must have completed

--- a/main.go
+++ b/main.go
@@ -934,7 +934,7 @@ func (task *TaskRun) Run() (err *executionErrors) {
 			// found, and so an error artifact was uploaded. So we do that
 			// here:
 			switch a := artifact.(type) {
-			case ErrorArtifact:
+			case *ErrorArtifact:
 				err.add(Failure(fmt.Errorf("%v: %v", a.Reason, a.Message)))
 			}
 		}


### PR DESCRIPTION
This now uses a blacklist of file extensions to _not_ gzip compress, everything else gets gzip content-encoding. Based on this [blacklist](https://github.com/evansd/whitenoise/blob/03f6ea846394e01cbfe0c730141b81eb8dd6e88a/whitenoise/compress.py#L21-L29).

CC @edmorley @gregarndt @jonasfj 