### PR TITLE
Setup correct PWD environment variable for child processes. r=pmoore

### DIFF
--- a/plat_all-unix-style.go
+++ b/plat_all-unix-style.go
@@ -99,6 +99,8 @@ func (task *TaskRun) EnvVars() []string {
 	for i, j := range taskEnv {
 		taskEnvArray = append(taskEnvArray, i+"="+j)
 	}
+	// PWD environment variable may be used for spawned scripts
+	taskEnv["PWD"] = taskContext.TaskDir
 	log.Printf("Environment: %#v", taskEnvArray)
 	return taskEnvArray
 }


### PR DESCRIPTION
PWD environment variable is generally handled by the shell.
Nevertheless, scripts may use it in strings that references environment
variables.