### PR TITLE
include name of generic-worker target

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ and reports back results to the queue.
 Simply run:
 
 ```
-generic-worker --config CONFIG-FILE
+generic-worker run --config CONFIG-FILE
 ```
 
 # Create a test job


### PR DESCRIPTION
Simply running `generic-worker --config CONFIG-FILE` displays usage, presumably because it's required to include the *run* target in the invocation.