### PR TITLE
Rename folder cross device windows

### DIFF
--- a/mounts_windows_test.go
+++ b/mounts_windows_test.go
@@ -34,7 +34,7 @@ func TestRenameCrossDevice(t *testing.T) {
 	}
 	sourceDir := "Z:\\a"
 	targetDir := filepath.Join(cwd, "a")
-	err = RenameFolderCrossDevice(sourceDir, targetDir)
+	err = RenameCrossDevice(sourceDir, targetDir)
 	if err != nil {
 		t.Fatalf("Hit error renaming folder %v as %v:\n%v", sourceDir, targetDir, err)
 	}

--- a/mounts_windows_test.go
+++ b/mounts_windows_test.go
@@ -1,44 +1,48 @@
 package main
 
-import "os"
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
-// This is an invalid test, commenting out for now.
-//
-// func TestRenameCrossDevice(t *testing.T) {
-// 	exists, err := exists("Z:\\")
-// 	if err != nil {
-// 		t.Fatal("Problem scanning for Z: drive")
-// 	}
-// 	if !exists {
-// 		t.Skip("Skipping test as Z: drive does not exist on this environment")
-// 	}
-// 	cwd, err := os.Getwd()
-// 	if err != nil {
-// 		t.Fatal("Could not access current directory")
-// 	}
-// 	if strings.HasPrefix(cwd, "Z:\\") {
-// 		t.Skip("Skipping test as current directory is already on Z: so rename would not be cross device (Z: -> Z:)")
-// 	}
-// 	err = os.MkdirAll("Z:\\a\\b", 0700)
-// 	if err != nil {
-// 		t.Fatal("Could not create directory Z:\\a\\b")
-// 	}
-// 	randomFile := "Z:\\a\\b\\randomFile.txt"
-// 	err = ioutil.WriteFile(randomFile, []byte("some content"), 0600)
-// 	if err != nil {
-// 		t.Fatalf("Hit error creating %v: %v", randomFile, err)
-// 	}
-// 	sourceDir := "Z:\\a"
-// 	targetDir := filepath.Join(cwd, "a")
-// 	err = RenameCrossDevice(sourceDir, targetDir)
-// 	if err != nil {
-// 		t.Fatalf("Hit error renaming folder %v as %v:\n%v", sourceDir, targetDir, err)
-// 	}
-// 	err = os.RemoveAll(targetDir)
-// 	if err != nil {
-// 		t.Fatalf("Could not clean up after test - not able to remove folder %v: %v", targetDir, err)
-// 	}
-// }
+func TestRenameCrossDevice(t *testing.T) {
+	exists, err := exists("Z:\\")
+	if err != nil {
+		t.Fatal("Problem scanning for Z: drive")
+	}
+	if !exists {
+		t.Skip("Skipping test as Z: drive does not exist on this environment")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("Could not access current directory")
+	}
+	if strings.HasPrefix(cwd, "Z:\\") {
+		t.Skip("Skipping test as current directory is already on Z: so rename would not be cross device (Z: -> Z:)")
+	}
+	err = os.MkdirAll("Z:\\a\\b", 0700)
+	if err != nil {
+		t.Fatal("Could not create directory Z:\\a\\b")
+	}
+	randomFile := "Z:\\a\\b\\randomFile.txt"
+	err = ioutil.WriteFile(randomFile, []byte("some content"), 0600)
+	if err != nil {
+		t.Fatalf("Hit error creating %v: %v", randomFile, err)
+	}
+	sourceDir := "Z:\\a"
+	targetDir := filepath.Join(cwd, "a")
+	err = RenameFolderCrossDevice(sourceDir, targetDir)
+	if err != nil {
+		t.Fatalf("Hit error renaming folder %v as %v:\n%v", sourceDir, targetDir, err)
+	}
+	err = os.RemoveAll(targetDir)
+	if err != nil {
+		t.Fatalf("Could not clean up after test - not able to remove folder %v: %v", targetDir, err)
+	}
+}
 
 func exists(path string) (bool, error) {
 	_, err := os.Stat(path)

--- a/plat_windows.go
+++ b/plat_windows.go
@@ -612,17 +612,35 @@ func makeDirUnreadable(dir string) error {
 // additionally sets the flag windows.MOVEFILE_COPY_ALLOWED in order to cater
 // for oldpath and newpath being on different drives. See:
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365240(v=vs.85).aspx
-// Note: this only works for files, not directories.
-func RenameCrossDevice(oldpath, newpath string) error {
-	from, err := syscall.UTF16PtrFromString(oldpath)
+func RenameCrossDevice(oldpath, newpath string) (err error) {
+	var to, from *uint16
+	from, err = syscall.UTF16PtrFromString(oldpath)
 	if err != nil {
-		return err
+		return
 	}
-	to, err := syscall.UTF16PtrFromString(newpath)
+	to, err = syscall.UTF16PtrFromString(newpath)
 	if err != nil {
-		return err
+		return
 	}
-	return windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_COPY_ALLOWED)
+	// this will work for files and directories on same drive, and even for
+	// files on different drives, but not for directories on different drives
+	err = windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_COPY_ALLOWED)
+
+	// if we fail, could be a folder that needs to be moved to a different
+	// drive - however, check it really is a folder, since otherwise we could
+	// end up infinitely recursing between RenameCrossDevice and
+	// RenameFolderCrossDevice, since they both call into each other
+	if err != nil {
+		var fi os.FileInfo
+		fi, err = os.Stat(oldpath)
+		if err != nil {
+			return
+		}
+		if fi.IsDir() {
+			err = RenameFolderCrossDevice(oldpath, newpath)
+		}
+	}
+	return
 }
 
 func RenameFolderCrossDevice(oldpath, newpath string) (err error) {
@@ -648,7 +666,7 @@ func RenameFolderCrossDevice(oldpath, newpath string) (err error) {
 	if err != nil {
 		return
 	}
-	err = os.Remove(oldpath)
+	err = os.RemoveAll(oldpath)
 	return
 }
 


### PR DESCRIPTION
Added support for moving folders across Windows volumes. This is useful so that writable caches can be stored on a _different_ volume to task folders, so e.g. we can format the drive with task folders between tasks (typically `Z:\`) without losing caches and downloads which can now be placed on e.g. `Y:\` or `C:\`.

Previously, caches had to be on the same drive (volume) as the task folders.