### PR TITLE
public/logs/chainOfTrust.json.asc => public/chainOfTrust.json.asc

### DIFF
--- a/all-unix-style.yml
+++ b/all-unix-style.yml
@@ -84,10 +84,10 @@ properties:
         type: boolean
         title: Enable generation of a openpgp signed Chain of Trust artifact
         description: |-
-          An artifact named chainOfTrust.json.asc should be generated
-          which will include information for downstream tasks to build
-          a level of trust for the artifacts produced by the task and
-          the environment it ran in.
+          An artifact named `public/chainOfTrust.json.asc` should be generated
+          which will include information for downstream tasks to build a level
+          of trust for the artifacts produced by the task and the environment
+          it ran in.
   mounts:
     type: array
     description: Directories and/or files to be mounted

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -436,7 +436,7 @@ func TestUpload(t *testing.T) {
 			contentEncoding: "gzip",
 			expires:         td.Expires,
 		},
-		"public/logs/chainOfTrust.json.asc": {
+		"public/chainOfTrust.json.asc": {
 			// e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  ./%%%/v/X
 			// 8308d593eb56527137532595a60255a3fcfbe4b6b068e29b22d99742bad80f6f  ./_/X.txt
 			// a0ed21ab50992121f08da55365da0336062205fd6e7953dbff781a7de0d625b7  ./b/c/d.jpg
@@ -495,7 +495,7 @@ func TestUpload(t *testing.T) {
 
 	// now check content was uploaded to Amazon, and is correct
 
-	// signer of public/logs/chainOfTrust.json.asc
+	// signer of public/chainOfTrust.json.asc
 	signer := &openpgp.Entity{}
 	cotCert := &ChainOfTrustData{}
 
@@ -533,7 +533,7 @@ func TestUpload(t *testing.T) {
 			t.Fatalf("Content-Type in Signed URL %v response (%v) does not match Content-Type of artifact (%v)", url, actualContentType, content.contentType)
 		}
 		// check openpgp signature is valid
-		if artifact == "public/logs/chainOfTrust.json.asc" {
+		if artifact == "public/chainOfTrust.json.asc" {
 			pubKey, err := os.Open(filepath.Join("testdata", "public-openpgp-key"))
 			if err != nil {
 				t.Fatalf("Error opening public key file")
@@ -546,19 +546,19 @@ func TestUpload(t *testing.T) {
 			block, _ := clearsign.Decode(b)
 			signer, err = openpgp.CheckDetachedSignature(entityList, bytes.NewBuffer(block.Bytes), block.ArmoredSignature.Body)
 			if err != nil {
-				t.Fatalf("Not able to validate openpgp signature of public/logs/chainOfTrust.json.asc")
+				t.Fatalf("Not able to validate openpgp signature of public/chainOfTrust.json.asc")
 			}
 			err = json.Unmarshal(block.Plaintext, cotCert)
 			if err != nil {
-				t.Fatalf("Could not interpret public/logs/chainOfTrust.json as json")
+				t.Fatalf("Could not interpret public/chainOfTrust.json as json")
 			}
 		}
 	}
 	if signer == nil {
-		t.Fatalf("Signer of public/logs/chainOfTrust.json.asc could not be established (is nil)")
+		t.Fatalf("Signer of public/chainOfTrust.json.asc could not be established (is nil)")
 	}
 	if signer.Identities["Generic-Worker <taskcluster-accounts+gpgsigning@mozilla.com>"] == nil {
-		t.Fatalf("Did not get correct signer identity in public/logs/chainOfTrust.json.asc - %#v", signer.Identities)
+		t.Fatalf("Did not get correct signer identity in public/chainOfTrust.json.asc - %#v", signer.Identities)
 	}
 
 	// This trickery is to convert a TaskDefinitionResponse into a

--- a/chain_of_trust.go
+++ b/chain_of_trust.go
@@ -80,7 +80,7 @@ func (cot *ChainOfTrustTaskFeature) Start() *CommandExecutionError {
 func (cot *ChainOfTrustTaskFeature) Stop() *CommandExecutionError {
 	logFile := filepath.Join(taskContext.TaskDir, "public", "logs", "live_backing.log")
 	certifiedLogFile := filepath.Join(taskContext.TaskDir, "public", "logs", "certified.log")
-	signedCert := filepath.Join(taskContext.TaskDir, "public", "logs", "chainOfTrust.json.asc")
+	signedCert := filepath.Join(taskContext.TaskDir, "public", "chainOfTrust.json.asc")
 	e := copyFileContents(logFile, certifiedLogFile)
 	if e != nil {
 		panic(e)
@@ -156,7 +156,7 @@ func (cot *ChainOfTrustTaskFeature) Stop() *CommandExecutionError {
 	w.Close()
 	out.Write([]byte{'\n'})
 	out.Close()
-	err = cot.task.uploadLog("public/logs/chainOfTrust.json.asc")
+	err = cot.task.uploadLog("public/chainOfTrust.json.asc")
 	if err != nil {
 		return err
 	}

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,8 +28,8 @@ Example:
 ## Feature: `chainOfTrust`
 
 Enabling this feature will mean that the generic worker will publish an
-additional task artifact `public/logs/chainOfTrust.json.asc`. This will be a
-clear text openpgp-signed json object, storing the SHA 256 hashes of the task
+additional task artifact `public/chainOfTrust.json.asc`. This will be a clear
+text openpgp-signed json object, storing the SHA 256 hashes of the task
 artifacts, plus some information about the worker. This is signed by a openpgp
 private key, both generated and stored on the worker. This private key is never
 transmitted across the network. In future you will be able to verify the

--- a/generated_all-unix-style.go
+++ b/generated_all-unix-style.go
@@ -69,10 +69,10 @@ type (
 		// Feature flags enable additional functionality.
 		Features struct {
 
-			// An artifact named chainOfTrust.json.asc should be generated
-			// which will include information for downstream tasks to build
-			// a level of trust for the artifacts produced by the task and
-			// the environment it ran in.
+			// An artifact named `public/chainOfTrust.json.asc` should be generated
+			// which will include information for downstream tasks to build a level
+			// of trust for the artifacts produced by the task and the environment
+			// it ran in.
 			ChainOfTrust bool `json:"chainOfTrust,omitempty"`
 		} `json:"features,omitempty"`
 
@@ -417,7 +417,7 @@ func taskPayloadSchema() string {
       "description": "Feature flags enable additional functionality.",
       "properties": {
         "chainOfTrust": {
-          "description": "An artifact named chainOfTrust.json.asc should be generated\nwhich will include information for downstream tasks to build\na level of trust for the artifacts produced by the task and\nthe environment it ran in.",
+          "description": "An artifact named ` + "`" + `public/chainOfTrust.json.asc` + "`" + ` should be generated\nwhich will include information for downstream tasks to build a level\nof trust for the artifacts produced by the task and the environment\nit ran in.",
           "title": "Enable generation of a openpgp signed Chain of Trust artifact",
           "type": "boolean"
         }

--- a/generated_windows.go
+++ b/generated_windows.go
@@ -69,10 +69,10 @@ type (
 		// Feature flags enable additional functionality.
 		Features struct {
 
-			// An artifact named chainOfTrust.json.asc should be generated
-			// which will include information for downstream tasks to build
-			// a level of trust for the artifacts produced by the task and
-			// the environment it ran in.
+			// An artifact named `public/chainOfTrust.json.asc` should be generated
+			// which will include information for downstream tasks to build a level
+			// of trust for the artifacts produced by the task and the environment
+			// it ran in.
 			ChainOfTrust bool `json:"chainOfTrust,omitempty"`
 		} `json:"features,omitempty"`
 
@@ -413,7 +413,7 @@ func taskPayloadSchema() string {
       "description": "Feature flags enable additional functionality.",
       "properties": {
         "chainOfTrust": {
-          "description": "An artifact named chainOfTrust.json.asc should be generated\nwhich will include information for downstream tasks to build\na level of trust for the artifacts produced by the task and\nthe environment it ran in.",
+          "description": "An artifact named ` + "`" + `public/chainOfTrust.json.asc` + "`" + ` should be generated\nwhich will include information for downstream tasks to build a level\nof trust for the artifacts produced by the task and the environment\nit ran in.",
           "title": "Enable generation of a openpgp signed Chain of Trust artifact",
           "type": "boolean"
         }

--- a/windows.yml
+++ b/windows.yml
@@ -82,10 +82,10 @@ properties:
         type: boolean
         title: Enable generation of a openpgp signed Chain of Trust artifact
         description: |-
-          An artifact named chainOfTrust.json.asc should be generated
-          which will include information for downstream tasks to build
-          a level of trust for the artifacts produced by the task and
-          the environment it ran in.
+          An artifact named `public/chainOfTrust.json.asc` should be generated
+          which will include information for downstream tasks to build a level
+          of trust for the artifacts produced by the task and the environment
+          it ran in.
   mounts:
     type: array
     description: Directories and/or files to be mounted


### PR DESCRIPTION
@Callek @escapewindow This should correct the chain of trust artifact name.