### PR TITLE
Bug 1383024 - Superseding

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -113,7 +113,7 @@ tasks:
         - cacheName: generic-worker-checkout
           directory: gopath\src
         - content:
-            url: https://storage.googleapis.com/golang/go1.7.5.windows-amd64.zip
+            url: https://storage.googleapis.com/golang/go1.8.3.windows-amd64.zip
           directory: .
           format: zip
         - content:
@@ -180,7 +180,7 @@ tasks:
         - cacheName: generic-worker-checkout
           directory: gopath\src
         - content:
-            url: https://storage.googleapis.com/golang/go1.7.5.windows-386.zip
+            url: https://storage.googleapis.com/golang/go1.8.3.windows-386.zip
           directory: .
           format: zip
         - content:
@@ -256,7 +256,7 @@ tasks:
         - cacheName: generic-worker-checkout
           directory: gopath\src
         - content:
-            url: https://storage.googleapis.com/golang/go1.7.5.windows-amd64.zip
+            url: https://storage.googleapis.com/golang/go1.8.3.windows-amd64.zip
           directory: .
           format: zip
         - content:
@@ -292,7 +292,7 @@ tasks:
         - - /bin/bash
           - -vxec
           - |
-            export GOROOT="$(pwd)/go1.8/go"
+            export GOROOT="$(pwd)/go1.8.3/go"
             export GOPATH="$(pwd)/gopath"
             export PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
             go version
@@ -326,8 +326,8 @@ tasks:
         - cacheName: generic-worker-checkout
           directory: gopath/src
         - content:
-            url: https://storage.googleapis.com/golang/go1.8.darwin-amd64.tar.gz
-          directory: go1.8
+            url: https://storage.googleapis.com/golang/go1.8.3.darwin-amd64.tar.gz
+          directory: go1.8.3
           format: tar.gz
 
 
@@ -335,64 +335,70 @@ tasks:
   #################### Linux ARM6 Build ####################
   ##########################################################
 
-  - provisionerId: pmoore-manual
-    workerType: raspberry-pi-3b
-    metadata:
-      name: "Build/test ARM6 generic-worker on Linux (Raspberry Pi)"
-      description: "This builds the ARM6 Linux version of generic-worker"
-      owner: "{{ event.head.user.email }}" # the user who sent the pr/push e-mail will be inserted here
-      source: "{{ event.head.repo.url }}"  # the repo where the pr came from will be inserted here
-    extra:
-      github:
-        # Events that will trigger this task
-        events:
-          - pull_request.*
-          - push
-    scopes:
-      - generic-worker:cache:generic-worker-checkout
-    payload:
-      maxRunTime: 3600
-      command:
-        - - /bin/bash
-          - -vxec
-          - |
-            export GOROOT="$(pwd)/go1.8/go"
-            export GOPATH="$(pwd)/gopath"
-            export PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
-            export CGO_ENABLED=0
-            go version
-            go env
-            source "${GW_CREDS_BOOTSTRAP}"
-            mkdir -p "${GOPATH}/src/github.com/taskcluster"
-            cd "${GOPATH}/src/github.com/taskcluster"
-            if [ ! -d generic-worker/.git ]; then rm -rf generic-worker; git clone '{{ event.head.repo.url }}' 'generic-worker'; fi
-            cd 'generic-worker'
-            git fetch '{{ event.head.repo.url }}' "+{{ event.head.ref }}:refs/heads/${TASK_ID}"
-            git checkout -f "${TASK_ID}"
-            git reset --hard '{{ event.head.sha }}'
-            git clean -fdx
-            git checkout -B tmp -t "${TASK_ID}"
-            go get -v github.com/taskcluster/livelog github.com/gordonklaus/ineffassign
-            cd gw-codegen
-            go get -v -u
-            cd ..
-            go generate
-            go get -v -u -t ./...
-            test "$(git status --porcelain | wc -l)" == 0
-            GORACE=history_size=7 go test -v ./...
-            ineffassign .
-      artifacts:
-        - name: public/build/generic-worker-linux-armv6l
-          path: gopath/bin/generic-worker
-          expires: "{{ '2 weeks' | $fromNow }}"
-          type: file
-      mounts:
-        - cacheName: generic-worker-checkout
-          directory: gopath/src
-        - content:
-            url: https://storage.googleapis.com/golang/go1.8.linux-armv6l.tar.gz
-          directory: go1.8
-          format: tar.gz
+
+  ##########################################################
+  # Currently Raspberry PI is not available (being used for other things)
+  # Will reenable when I have it back again
+  ##########################################################
+
+  # - provisionerId: pmoore-manual
+  #   workerType: raspberry-pi-3b
+  #   metadata:
+  #     name: "Build/test ARM6 generic-worker on Linux (Raspberry Pi)"
+  #     description: "This builds the ARM6 Linux version of generic-worker"
+  #     owner: "{{ event.head.user.email }}" # the user who sent the pr/push e-mail will be inserted here
+  #     source: "{{ event.head.repo.url }}"  # the repo where the pr came from will be inserted here
+  #   extra:
+  #     github:
+  #       # Events that will trigger this task
+  #       events:
+  #         - pull_request.*
+  #         - push
+  #   scopes:
+  #     - generic-worker:cache:generic-worker-checkout
+  #   payload:
+  #     maxRunTime: 3600
+  #     command:
+  #       - - /bin/bash
+  #         - -vxec
+  #         - |
+  #           export GOROOT="$(pwd)/go1.8.3/go"
+  #           export GOPATH="$(pwd)/gopath"
+  #           export PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
+  #           export CGO_ENABLED=0
+  #           go version
+  #           go env
+  #           source "${GW_CREDS_BOOTSTRAP}"
+  #           mkdir -p "${GOPATH}/src/github.com/taskcluster"
+  #           cd "${GOPATH}/src/github.com/taskcluster"
+  #           if [ ! -d generic-worker/.git ]; then rm -rf generic-worker; git clone '{{ event.head.repo.url }}' 'generic-worker'; fi
+  #           cd 'generic-worker'
+  #           git fetch '{{ event.head.repo.url }}' "+{{ event.head.ref }}:refs/heads/${TASK_ID}"
+  #           git checkout -f "${TASK_ID}"
+  #           git reset --hard '{{ event.head.sha }}'
+  #           git clean -fdx
+  #           git checkout -B tmp -t "${TASK_ID}"
+  #           go get -v github.com/taskcluster/livelog github.com/gordonklaus/ineffassign
+  #           cd gw-codegen
+  #           go get -v -u
+  #           cd ..
+  #           go generate
+  #           go get -v -u -t ./...
+  #           test "$(git status --porcelain | wc -l)" == 0
+  #           GORACE=history_size=7 go test -v ./...
+  #           ineffassign .
+  #     artifacts:
+  #       - name: public/build/generic-worker-linux-armv6l
+  #         path: gopath/bin/generic-worker
+  #         expires: "{{ '2 weeks' | $fromNow }}"
+  #         type: file
+  #     mounts:
+  #       - cacheName: generic-worker-checkout
+  #         directory: gopath/src
+  #       - content:
+  #           url: https://storage.googleapis.com/golang/go1.8.3.linux-armv6l.tar.gz
+  #         directory: go1.8.3
+  #         format: tar.gz
 
 
   ##########################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
 go:
-  # this is a lie - we will use 1.7 which isn't supported yet
+  # this is a lie - we will use 1.8.3 which isn't supported yet
   # by downloading it later in "before_install" section
-  # we use 1.7 due to https://github.com/contester/runlib/issues/5#issuecomment-241419381
+  # we use 1.8.3 due to https://github.com/contester/runlib/issues/5#issuecomment-241419381
   # which could have also been achieved via vendoring an older version, but for let's
   # keep up-to-date with latest version
   - 1.6
@@ -15,7 +15,7 @@ env:
   - "MY_GOOS=windows MY_GOARCH=386"
 
 before_install:
-  - curl -o go.tar.gz -sL https://storage.googleapis.com/golang/go1.7.5.linux-amd64.tar.gz
+  - curl -o go.tar.gz -sL https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
   - tar -C $HOME -xf go.tar.gz
   - rm go.tar.gz
   - export GOROOT="${HOME}/go"

--- a/all-unix-style.yml
+++ b/all-unix-style.yml
@@ -118,8 +118,8 @@ properties:
       URL of the a service that can indicate tasks superseding this one; the current `taskId`
       will be appended as a query argument `taskId`. The service should return an object with
       a `supersedes` key containing a list of `taskId`s, including the supplied `taskId`. The
-      tasks should be ordered such that each task supersedes all tasks appearing earlier in
-      the list.
+      tasks should be ordered such that each task supersedes all tasks appearing later in the
+      list.
     format: uri
 definitions:
   mount:

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -1,0 +1,16 @@
+package fileutil
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+)
+
+func WriteToFileAsJSON(obj interface{}, filename string) error {
+	jsonBytes, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return err
+	}
+	log.Printf("Saving file %v with content:\n%v\n", filename, string(jsonBytes))
+	return ioutil.WriteFile(filename, append(jsonBytes, '\n'), 0644)
+}

--- a/generated_all-unix-style.go
+++ b/generated_all-unix-style.go
@@ -99,8 +99,8 @@ type (
 		// URL of the a service that can indicate tasks superseding this one; the current `taskId`
 		// will be appended as a query argument `taskId`. The service should return an object with
 		// a `supersedes` key containing a list of `taskId`s, including the supplied `taskId`. The
-		// tasks should be ordered such that each task supersedes all tasks appearing earlier in
-		// the list.
+		// tasks should be ordered such that each task supersedes all tasks appearing later in the
+		// list.
 		SupersederURL string `json:"supersederUrl,omitempty"`
 	}
 
@@ -464,7 +464,7 @@ func taskPayloadSchema() string {
       "type": "array"
     },
     "supersederUrl": {
-      "description": "URL of the a service that can indicate tasks superseding this one; the current ` + "`" + `taskId` + "`" + `\nwill be appended as a query argument ` + "`" + `taskId` + "`" + `. The service should return an object with\na ` + "`" + `supersedes` + "`" + ` key containing a list of ` + "`" + `taskId` + "`" + `s, including the supplied ` + "`" + `taskId` + "`" + `. The\ntasks should be ordered such that each task supersedes all tasks appearing earlier in\nthe list.",
+      "description": "URL of the a service that can indicate tasks superseding this one; the current ` + "`" + `taskId` + "`" + `\nwill be appended as a query argument ` + "`" + `taskId` + "`" + `. The service should return an object with\na ` + "`" + `supersedes` + "`" + ` key containing a list of ` + "`" + `taskId` + "`" + `s, including the supplied ` + "`" + `taskId` + "`" + `. The\ntasks should be ordered such that each task supersedes all tasks appearing later in the\nlist.",
       "format": "uri",
       "title": "Superseder URL",
       "type": "string"

--- a/generated_windows.go
+++ b/generated_windows.go
@@ -99,8 +99,8 @@ type (
 		// URL of the a service that can indicate tasks superseding this one; the current `taskId`
 		// will be appended as a query argument `taskId`. The service should return an object with
 		// a `supersedes` key containing a list of `taskId`s, including the supplied `taskId`. The
-		// tasks should be ordered such that each task supersedes all tasks appearing earlier in
-		// the list.
+		// tasks should be ordered such that each task supersedes all tasks appearing later in the
+		// list.
 		SupersederURL string `json:"supersederUrl,omitempty"`
 	}
 
@@ -460,7 +460,7 @@ func taskPayloadSchema() string {
       "type": "array"
     },
     "supersederUrl": {
-      "description": "URL of the a service that can indicate tasks superseding this one; the current ` + "`" + `taskId` + "`" + `\nwill be appended as a query argument ` + "`" + `taskId` + "`" + `. The service should return an object with\na ` + "`" + `supersedes` + "`" + ` key containing a list of ` + "`" + `taskId` + "`" + `s, including the supplied ` + "`" + `taskId` + "`" + `. The\ntasks should be ordered such that each task supersedes all tasks appearing earlier in\nthe list.",
+      "description": "URL of the a service that can indicate tasks superseding this one; the current ` + "`" + `taskId` + "`" + `\nwill be appended as a query argument ` + "`" + `taskId` + "`" + `. The service should return an object with\na ` + "`" + `supersedes` + "`" + ` key containing a list of ` + "`" + `taskId` + "`" + `s, including the supplied ` + "`" + `taskId` + "`" + `. The\ntasks should be ordered such that each task supersedes all tasks appearing later in the\nlist.",
       "format": "uri",
       "title": "Superseder URL",
       "type": "string"

--- a/gwconfig/config.go
+++ b/gwconfig/config.go
@@ -1,10 +1,10 @@
 package gwconfig
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net"
+
+	"github.com/taskcluster/generic-worker/fileutil"
 )
 
 type (
@@ -54,14 +54,5 @@ type (
 // writes config to json file
 func (c *Config) Persist(file string) error {
 	log.Print("Creating file " + file + "...")
-	return WriteToFileAsJSON(c, file)
-}
-
-func WriteToFileAsJSON(obj interface{}, filename string) error {
-	jsonBytes, err := json.MarshalIndent(obj, "", "  ")
-	if err != nil {
-		return err
-	}
-	log.Printf("Saving file %v with content:\n%v\n", filename, string(jsonBytes))
-	return ioutil.WriteFile(filename, append(jsonBytes, '\n'), 0644)
+	return fileutil.WriteToFileAsJSON(c, file)
 }

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ var (
 		&OSGroupsFeature{},
 		&ChainOfTrustFeature{},
 		&MountsFeature{},
+		&SupersedeFeature{},
 	}
 
 	version = "10.1.8"

--- a/mounts.go
+++ b/mounts.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/mholt/archiver"
-	"github.com/taskcluster/generic-worker/gwconfig"
+	"github.com/taskcluster/generic-worker/fileutil"
 	"github.com/taskcluster/httpbackoff"
 	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster-base-go/scopes"
@@ -102,11 +102,11 @@ func (feature *MountsFeature) Name() string {
 }
 
 func (feature *MountsFeature) PersistState() (err error) {
-	err = gwconfig.WriteToFileAsJSON(&fileCaches, "file-caches.json")
+	err = fileutil.WriteToFileAsJSON(&fileCaches, "file-caches.json")
 	if err != nil {
 		return
 	}
-	err = gwconfig.WriteToFileAsJSON(&directoryCaches, "directory-caches.json")
+	err = fileutil.WriteToFileAsJSON(&directoryCaches, "directory-caches.json")
 	return
 }
 

--- a/supersede.go
+++ b/supersede.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/taskcluster/generic-worker/gwconfig"
+	"github.com/taskcluster/httpbackoff"
+	"github.com/taskcluster/taskcluster-base-go/scopes"
+)
+
+var (
+	supersededByPath = filepath.Join("generic-worker", "superseded-by.json")
+	supersededByName = "public/superseded-by.json"
+)
+
+type SupersedeFeature struct {
+}
+
+type SupersedesServiceResponse struct {
+	TaskIDs []string `json:"supersedes"`
+}
+
+func (feature *SupersedeFeature) Name() string {
+	return "Supersede"
+}
+
+func (feature *SupersedeFeature) Initialise() error {
+	return nil
+}
+
+func (feature *SupersedeFeature) PersistState() error {
+	return nil
+}
+
+// Supersede is always enabled
+func (feature *SupersedeFeature) IsEnabled(fl EnabledFeatures) bool {
+	return true
+}
+
+type SupersedeTask struct {
+	task *TaskRun
+}
+
+func (feature *SupersedeFeature) NewTaskFeature(task *TaskRun) TaskFeature {
+	task.featureArtifacts[supersededByName] = "superseded feature"
+	return &SupersedeTask{
+		task: task,
+	}
+}
+
+func (l *SupersedeTask) RequiredScopes() scopes.Required {
+	// let's not require any scopes, as I see no reason to control access to this feature
+	return scopes.Required{}
+}
+
+func (l *SupersedeTask) Start() *CommandExecutionError {
+	supersederURL := l.task.Payload.SupersederURL
+	if supersederURL == "" {
+		return nil
+	}
+	resp, _, err := httpbackoff.Get(supersederURL)
+	if err != nil {
+		return MalformedPayloadError(err)
+	}
+	decoder := json.NewDecoder(resp.Body)
+	var supersedes SupersedesServiceResponse
+	err = decoder.Decode(&supersedes)
+	if err != nil {
+		return MalformedPayloadError(err)
+	}
+	taskIDs := supersedes.TaskIDs
+	if l.task.TaskID != taskIDs[0] {
+		supersededByFile := filepath.Join(taskContext.TaskDir, supersededByPath)
+		err = gwconfig.WriteToFileAsJSON(
+			map[string]string{
+				"taskId": taskIDs[0],
+			},
+			supersededByFile,
+		)
+		if err != nil {
+			panic(err)
+		}
+		e := l.task.uploadArtifact(
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
+					Name:    supersededByName,
+					Expires: l.task.Definition.Expires,
+				},
+				Path:            supersededByPath,
+				ContentEncoding: "gzip",
+				MimeType:        "application/json",
+			},
+		)
+		if e != nil {
+			panic(e)
+		}
+		return &CommandExecutionError{
+			TaskStatus: aborted,
+			Cause:      fmt.Errorf("Task %v has been superseded by task %v", l.task.TaskID, taskIDs[0]),
+			Reason:     Superseded,
+		}
+	}
+	return nil
+}
+
+func (l *SupersedeTask) Stop() *CommandExecutionError {
+	return nil
+}

--- a/supersede_test.go
+++ b/supersede_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestSupersede(t *testing.T) {
+	setup(t, "TestSupersede")
+	defer teardown(t)
+
+	command := helloGoodbye()
+
+	taskIDs := make([]string, 3)
+	for i := 0; i < len(taskIDs); i++ {
+		payload := GenericWorkerPayload{
+			Command:       command,
+			MaxRunTime:    30,
+			SupersederURL: "http://localhost:52856/",
+		}
+		td := testTask(t)
+
+		taskIDs[i] = scheduleTask(t, td, payload)
+	}
+	serviceResponse := SupersedesServiceResponse{
+		TaskIDs: taskIDs,
+	}
+
+	s := http.Server{
+		Addr: ":52856",
+	}
+
+	serviceResponseBody, err := json.Marshal(serviceResponse)
+	if err != nil {
+		t.Fatalf("Could not marshal service response body into json: %v", err)
+	}
+
+	http.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
+		_, err := res.Write(serviceResponseBody)
+		if err != nil {
+			t.Fatalf("Mock supersede service could not write http response: %v", err)
+		}
+	})
+
+	go s.ListenAndServe()
+	defer s.Shutdown(context.Background())
+
+	for i, taskID := range taskIDs {
+		t.Logf("Executing task %v", taskID)
+		execute(t)
+		if i == 0 {
+			ensureResolution(t, taskID, "completed", "completed")
+		} else {
+			ensureResolution(t, taskID, "exception", "superseded")
+			x, _, _, _ := getArtifactContent(t, taskID, "public/superseded-by.json")
+			var actualData interface{}
+			err = json.Unmarshal(x, &actualData)
+			if err != nil {
+				t.Fatalf("Error unmarshaling public/superseded-by.json into json: %v", err)
+			}
+			expectedData := map[string]interface{}{
+				"taskId": taskIDs[0],
+			}
+			if !reflect.DeepEqual(actualData, expectedData) {
+				t.Fatalf("public/superseded-by.json has unexpected content in task %v.\nActual: %#v\nExpected: %#v", taskID, actualData, expectedData)
+			}
+		}
+	}
+}

--- a/windows.yml
+++ b/windows.yml
@@ -116,8 +116,8 @@ properties:
       URL of the a service that can indicate tasks superseding this one; the current `taskId`
       will be appended as a query argument `taskId`. The service should return an object with
       a `supersedes` key containing a list of `taskId`s, including the supplied `taskId`. The
-      tasks should be ordered such that each task supersedes all tasks appearing earlier in
-      the list.
+      tasks should be ordered such that each task supersedes all tasks appearing later in the
+      list.
     format: uri
 definitions:
   mount:


### PR DESCRIPTION
This initial implementation is simpler than the docker-worker implementation.  I have chosen an initial simpler implementation for the following reasons:

1. it is simpler, and therefore less likely to break or contain bugs, which is important as I will be on PTO for two weeks
2. I also believe it is a better implementation

Differences to docker-worker implementation

Docker worker claims all tasks it finds listed in the superseded service response body. It keeps claims on those tasks while the primary task (the task it has claimed which is not superseded by any other tasks it has claimed) is running. It then resolves all tasks upon completion of the primary task, attaching artifacts to identify which task run superseded a given task run, and which tasks were superseded by a given task run.

The problems I found with this approach are:

1. There is a bug, that if the primary task is aborted (e.g. due to max runtime being exceeded) or the claim is expired (worker crash, loss of connectivity with queue, etc), the non-primary tasks will be "released" by resolving them as worker shutdown, but future runs of those tasks will not employ superseding, since this relies on run 0 of the task being claimed, which has already been resolved as worker-shutdown

2. For users watching their tasks, they will see their task is claimed, and it will appear to have "hung" with no logs being displayed. It will stay in state "running" until the primary task has completed (which could be for example, an hour) without any information about what is going on. This task has been superseded, so will never be run, and so the user may not realise this until an hour later, at which point, if it is a critical task, they will need to run it again (if the superseding task is not sufficient for their purposes). This is a very bad user experience, when the worker knows immediately, that the task is going to be superseded.

3. This is a complex implementation, there are many workflows that have to be considered: task abortion, cancelation, crashes, deadlines expiring of some but not all tasks during task claims. With all these workflows to consider, the chance of bugs is high (for example, I discovered bug described in comment 1, and some others that have been fixed, but there could be several more).

4. "Running" task counts are inaccurate, since it will appear that more tasks are running than actually are. This could affect, among other things, provisioning logic that now or in the future might consider how many available slots there are for executing tasks, and what scaling ratio to use for scaling up worker pools.

5. It is not entirely efficient to claim all of the tasks at once. Consider, that tasks A, B, C are claimed, where C is the primary task. As task C is running, a new task D can come in, which supersedes C. If we had only checked the supersedes URL at the point task C was claimed using claimWork call of the queue, task D may have already been listed, and thus task D only would be run, rather than tasks C and D (i.e. if we can delay execution to when a task is returned by claimWork, rather than explicitly claiming with claimTask).

6. In the case that other bugs were fixed, each time a primary task is aborted/cancelled/claim-expired, a run is "used up" with worker-shutdown exception. If 6 aborts happen for a line of 100 superseded tasks, even with the bug described in comment 1 being fixed, all of these tasks would now be expired/worker-shutdown on all task runs, and we would lose the information that they were actually superseded at all, and have no idea which task superseded them.

7. The docker-worker implementation relies on both queue.claimWork and queue.claimTask, which prevents us from deprecating claimTask.

8. Migrating superseding from the worker into the queue, with this current design, is non-trivial. It means we need a redesign, if we want to move superseding out of the worker and into the queue (which is the better place for it to be, as then it is written once centrally, and applies to all workers globally).


In light of all the above points, it made sense to apply a considerably simpler algorithm, that solved all 8 of these issues(!) The simpler algorithm looks like this:

1. Claim work. Check the supersedingUrl. If the task is not the very first entry in the list, mark it as superseded by the first entry in the list.

 The only thing I see we lose here, is that the task that supersedes other tasks, does not know which tasks it superseded. However, I don't believe this is useful information. If a task is scheduled, and it is executed, the author of that task should not be concerned about what other tasks might have been scheduled that were then superceded, as it bears no consequence on this task. However, the tasks that were superseded still track which task superseded them, which I think is the only path of interest to follow. The author of a task, whose task is superseded, is interested in the task that superseded it, since it holds the result of the task that is relevant to him/her.

Therefore I see only advantages in this approach, and consider it much easier to maintain/reason about, due to its much greater simplicity. It provides quicker feedback, burns down the queue more quickly, is more reliable generally across a broader number of use cases, and doesn't miss anything that the docker-worker implementation offers.