### PR TITLE
Bug 1394557 - retry artifact uploads with HTTP 400 status code response

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -223,6 +223,9 @@ func (artifact *S3Artifact) ProcessResponse(resp interface{}, task *TaskRun) (er
 			log.Print(string(requestHeaders))
 		}
 		putResp, tempError = httpClient.Do(httpRequest)
+		if tempError != nil {
+			return
+		}
 		// bug 1394557: s3 incorrectly returns HTTP 400 for connection inactivity,
 		// which can/should be retried, so explicitly handle...
 		if putResp.StatusCode == 400 {

--- a/artifacts.go
+++ b/artifacts.go
@@ -191,21 +191,24 @@ func (artifact *S3Artifact) ProcessResponse(resp interface{}, task *TaskRun) (er
 
 	// perform http PUT to upload to S3...
 	httpClient := &http.Client{}
-	httpCall := func() (*http.Response, error, error) {
-		transferContent, err := os.Open(transferContentFile)
-		if err != nil {
-			return nil, nil, err
+	httpCall := func() (putResp *http.Response, tempError error, permError error) {
+		var transferContent *os.File
+		transferContent, permError = os.Open(transferContentFile)
+		if permError != nil {
+			return
 		}
 		defer transferContent.Close()
-		transferContentFileInfo, err := transferContent.Stat()
-		if err != nil {
-			return nil, nil, err
+		var transferContentFileInfo os.FileInfo
+		transferContentFileInfo, permError = transferContent.Stat()
+		if permError != nil {
+			return
 		}
 		transferContentLength := transferContentFileInfo.Size()
 
-		httpRequest, err := http.NewRequest("PUT", response.PutURL, transferContent)
-		if err != nil {
-			return nil, nil, err
+		var httpRequest *http.Request
+		httpRequest, permError = http.NewRequest("PUT", response.PutURL, transferContent)
+		if permError != nil {
+			return
 		}
 		httpRequest.Header.Set("Content-Type", artifact.MimeType)
 		httpRequest.ContentLength = transferContentLength
@@ -219,8 +222,13 @@ func (artifact *S3Artifact) ProcessResponse(resp interface{}, task *TaskRun) (er
 			log.Print("Request")
 			log.Print(string(requestHeaders))
 		}
-		putResp, err := httpClient.Do(httpRequest)
-		return putResp, err, nil
+		putResp, tempError = httpClient.Do(httpRequest)
+		// bug 1394557: s3 incorrectly returns HTTP 400 for connection inactivity,
+		// which can/should be retried, so explicitly handle...
+		if putResp.StatusCode == 400 {
+			tempError = fmt.Errorf("S3 returned status code 400 which could be an intermittent issue - see https://bugzilla.mozilla.org/show_bug.cgi?id=1394557")
+		}
+		return
 	}
 	putResp, putAttempts, err := httpbackoff.Retry(httpCall)
 	log.Printf("%v put requests issued to %v", putAttempts, response.PutURL)


### PR DESCRIPTION
I decided to retry _all_ HTTP 400 errors, rather than just trying to catch connection inactivity ones, since a production 400 error should be a relatively rare event (generally implying a bug in the code).