### PR TITLE
Bug 1382204 - handle empty supersedes list

### DIFF
--- a/supersede.go
+++ b/supersede.go
@@ -77,6 +77,9 @@ func (l *SupersedeTask) Start() *CommandExecutionError {
 		return nil
 	}
 	taskIDs := supersedes.TaskIDs
+	if len(taskIDs) < 1 {
+		return nil
+	}
 	if l.task.TaskID != taskIDs[0] {
 		supersededByFile := filepath.Join(taskContext.TaskDir, supersededByPath)
 		err = fileutil.WriteToFileAsJSON(

--- a/supersede_test.go
+++ b/supersede_test.go
@@ -19,7 +19,7 @@ func TestSupersede(t *testing.T) {
 		payload := GenericWorkerPayload{
 			Command:       command,
 			MaxRunTime:    30,
-			SupersederURL: "http://localhost:52856/",
+			SupersederURL: "http://localhost:52856/TestSupersede",
 		}
 		td := testTask(t)
 
@@ -38,7 +38,7 @@ func TestSupersede(t *testing.T) {
 		t.Fatalf("Could not marshal service response body into json: %v", err)
 	}
 
-	http.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
+	http.HandleFunc("/TestSupersede", func(res http.ResponseWriter, req *http.Request) {
 		_, err := res.Write(serviceResponseBody)
 		if err != nil {
 			t.Fatalf("Mock supersede service could not write http response: %v", err)
@@ -78,7 +78,7 @@ func TestEmptySupersedeList(t *testing.T) {
 	payload := GenericWorkerPayload{
 		Command:       helloGoodbye(),
 		MaxRunTime:    30,
-		SupersederURL: "http://localhost:52856/",
+		SupersederURL: "http://localhost:52856/TestEmptySupersedeList",
 	}
 	td := testTask(t)
 
@@ -93,7 +93,7 @@ func TestEmptySupersedeList(t *testing.T) {
 		t.Fatalf("Could not marshal service response body into json: %v", err)
 	}
 
-	http.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
+	http.HandleFunc("/TestEmptySupersedeList", func(res http.ResponseWriter, req *http.Request) {
 		_, err := res.Write(serviceResponseBody)
 		if err != nil {
 			t.Fatalf("Mock supersede service could not write http response: %v", err)

--- a/supersede_test.go
+++ b/supersede_test.go
@@ -70,3 +70,40 @@ func TestSupersede(t *testing.T) {
 		}
 	}
 }
+
+func TestEmptySupersedeList(t *testing.T) {
+	setup(t, "TestSupersede")
+	defer teardown(t)
+
+	payload := GenericWorkerPayload{
+		Command:       helloGoodbye(),
+		MaxRunTime:    30,
+		SupersederURL: "http://localhost:52856/",
+	}
+	td := testTask(t)
+
+	taskID := scheduleTask(t, td, payload)
+
+	s := http.Server{
+		Addr: ":52856",
+	}
+
+	serviceResponseBody, err := json.Marshal(SupersedesServiceResponse{})
+	if err != nil {
+		t.Fatalf("Could not marshal service response body into json: %v", err)
+	}
+
+	http.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
+		_, err := res.Write(serviceResponseBody)
+		if err != nil {
+			t.Fatalf("Mock supersede service could not write http response: %v", err)
+		}
+	})
+
+	go s.ListenAndServe()
+	defer s.Shutdown(context.Background())
+
+	t.Logf("Executing task %v", taskID)
+	execute(t)
+	ensureResolution(t, taskID, "completed", "completed")
+}


### PR DESCRIPTION
Previously, [generic-worker would crash](https://public-artifacts.taskcluster.net/Ya39sUGTSgmR9BOa65ogcA/4/public/logs/live_backing.log) if the supersedes list was empty.

Fixed, and added a test to check for it.