### PR TITLE
Bug 1415088 - include generic-worker version, GOOS and GOARCH in sentry reports

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"runtime"
 	"strconv"
 
 	raven "github.com/getsentry/raven-go"
@@ -47,6 +48,9 @@ func ReportCrashToSentry(r interface{}) {
 			"workerGroup":           config.WorkerGroup,
 			"workerId":              config.WorkerID,
 			"workerType":            config.WorkerType,
+			"gwVersion":             version,
+			"GOOS":                  runtime.GOOS,
+			"GOARCH":                runtime.GOARCH,
 		},
 	)
 }


### PR DESCRIPTION
This should make troubleshooting a bit easier.