### PR TITLE
Bug 1423215 - Make contentType an optional property of file artifact in task payload

### DIFF
--- a/all-unix-style.yml
+++ b/all-unix-style.yml
@@ -80,6 +80,19 @@ properties:
           description: |-
             Date when artifact should expire must be in the future, no earlier than task deadline, but
             no later than task expiry. If not set, defaults to task expiry.
+        contentType:
+          title: Content-Type header when serving artifact over HTTP
+          type: string
+          description: |-
+            Explicitly set the value of the HTTP `Content-Type` response header when the artifact(s)
+            is/are served over HTTP(S). If not provided (this property is optional) the worker will
+            guess the content type of artifacts based on the filename extension of the file storing
+            the artifact content. It does this by looking at the system filename-to-mimetype mappings
+            defined in multiple `mime.types` files located under `/etc`. Note, setting `contentType`
+            on a directory artifact will apply the same contentType to all files contained in the
+            directory.
+
+            See [mime.TypeByExtension](https://godoc.org/mime#TypeByExtension).
       required:
       - type
       - path

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -36,10 +36,11 @@ func validateArtifacts(
 	tr := &TaskRun{
 		Payload: GenericWorkerPayload{
 			Artifacts: []struct {
-				Expires tcclient.Time `json:"expires,omitempty"`
-				Name    string        `json:"name,omitempty"`
-				Path    string        `json:"path"`
-				Type    string        `json:"type"`
+				ContentType string        `json:"contentType,omitempty"`
+				Expires     tcclient.Time `json:"expires,omitempty"`
+				Name        string        `json:"name,omitempty"`
+				Path        string        `json:"path"`
+				Type        string        `json:"type"`
 			}{},
 		},
 		Definition: queue.TaskDefinitionResponse{
@@ -77,11 +78,41 @@ func TestFileArtifactWithNames(t *testing.T) {
 		[]Artifact{
 			&S3Artifact{
 				BaseArtifact: &BaseArtifact{
-					Name:    "public/build/firefox.exe",
-					Expires: inAnHour,
+					Name:     "public/build/firefox.exe",
+					Expires:  inAnHour,
+					MimeType: "text/plain; charset=utf-8",
 				},
-				Path:     "SampleArtifacts/_/X.txt",
-				MimeType: "text/plain; charset=utf-8",
+				Path: "SampleArtifacts/_/X.txt",
+			},
+		})
+}
+
+func TestFileArtifactWithContentType(t *testing.T) {
+
+	setup(t, "TestFileArtifactWithContentType")
+	defer teardown(t)
+	validateArtifacts(t,
+
+		// what appears in task payload
+		[]PayloadArtifact{
+			{
+				Expires:     inAnHour,
+				Path:        "SampleArtifacts/_/X.txt",
+				Type:        "file",
+				Name:        "public/build/firefox.exe",
+				ContentType: "application/octet-stream",
+			},
+		},
+
+		// what we expect to discover on file system
+		[]Artifact{
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
+					Name:     "public/build/firefox.exe",
+					Expires:  inAnHour,
+					MimeType: "application/octet-stream",
+				},
+				Path: "SampleArtifacts/_/X.txt",
 			},
 		})
 }
@@ -106,27 +137,73 @@ func TestDirectoryArtifactWithNames(t *testing.T) {
 		[]Artifact{
 			&S3Artifact{
 				BaseArtifact: &BaseArtifact{
-					Name:    "public/b/c/%%%/v/X",
-					Expires: inAnHour,
+					Name:     "public/b/c/%%%/v/X",
+					Expires:  inAnHour,
+					MimeType: "application/octet-stream",
 				},
-				Path:     filepath.Join("SampleArtifacts", "%%%", "v", "X"),
-				MimeType: "application/octet-stream",
+				Path: filepath.Join("SampleArtifacts", "%%%", "v", "X"),
 			},
 			&S3Artifact{
 				BaseArtifact: &BaseArtifact{
-					Name:    "public/b/c/_/X.txt",
-					Expires: inAnHour,
+					Name:     "public/b/c/_/X.txt",
+					Expires:  inAnHour,
+					MimeType: "text/plain; charset=utf-8",
 				},
-				Path:     filepath.Join("SampleArtifacts", "_", "X.txt"),
-				MimeType: "text/plain; charset=utf-8",
+				Path: filepath.Join("SampleArtifacts", "_", "X.txt"),
 			},
 			&S3Artifact{
 				BaseArtifact: &BaseArtifact{
-					Name:    "public/b/c/b/c/d.jpg",
-					Expires: inAnHour,
+					Name:     "public/b/c/b/c/d.jpg",
+					Expires:  inAnHour,
+					MimeType: "image/jpeg",
 				},
-				Path:     filepath.Join("SampleArtifacts", "b", "c", "d.jpg"),
-				MimeType: "image/jpeg",
+				Path: filepath.Join("SampleArtifacts", "b", "c", "d.jpg"),
+			},
+		})
+}
+
+func TestDirectoryArtifactWithContentType(t *testing.T) {
+
+	setup(t, "TestDirectoryArtifactWithContentType")
+	defer teardown(t)
+	validateArtifacts(t,
+
+		// what appears in task payload
+		[]PayloadArtifact{
+			{
+				Expires:     inAnHour,
+				Path:        "SampleArtifacts",
+				Type:        "directory",
+				Name:        "public/b/c",
+				ContentType: "text/plain; charset=utf-8",
+			},
+		},
+
+		// what we expect to discover on file system
+		[]Artifact{
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
+					Name:     "public/b/c/%%%/v/X",
+					Expires:  inAnHour,
+					MimeType: "text/plain; charset=utf-8",
+				},
+				Path: filepath.Join("SampleArtifacts", "%%%", "v", "X"),
+			},
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
+					Name:     "public/b/c/_/X.txt",
+					Expires:  inAnHour,
+					MimeType: "text/plain; charset=utf-8",
+				},
+				Path: filepath.Join("SampleArtifacts", "_", "X.txt"),
+			},
+			&S3Artifact{
+				BaseArtifact: &BaseArtifact{
+					Name:     "public/b/c/b/c/d.jpg",
+					Expires:  inAnHour,
+					MimeType: "text/plain; charset=utf-8",
+				},
+				Path: filepath.Join("SampleArtifacts", "b", "c", "d.jpg"),
 			},
 		})
 }
@@ -152,27 +229,27 @@ func TestDirectoryArtifacts(t *testing.T) {
 		[]Artifact{
 			&S3Artifact{
 				BaseArtifact: &BaseArtifact{
-					Name:    "SampleArtifacts/%%%/v/X",
-					Expires: inAnHour,
+					Name:     "SampleArtifacts/%%%/v/X",
+					Expires:  inAnHour,
+					MimeType: "application/octet-stream",
 				},
-				Path:     filepath.Join("SampleArtifacts", "%%%", "v", "X"),
-				MimeType: "application/octet-stream",
+				Path: filepath.Join("SampleArtifacts", "%%%", "v", "X"),
 			},
 			&S3Artifact{
 				BaseArtifact: &BaseArtifact{
-					Name:    "SampleArtifacts/_/X.txt",
-					Expires: inAnHour,
+					Name:     "SampleArtifacts/_/X.txt",
+					Expires:  inAnHour,
+					MimeType: "text/plain; charset=utf-8",
 				},
-				Path:     filepath.Join("SampleArtifacts", "_", "X.txt"),
-				MimeType: "text/plain; charset=utf-8",
+				Path: filepath.Join("SampleArtifacts", "_", "X.txt"),
 			},
 			&S3Artifact{
 				BaseArtifact: &BaseArtifact{
-					Name:    "SampleArtifacts/b/c/d.jpg",
-					Expires: inAnHour,
+					Name:     "SampleArtifacts/b/c/d.jpg",
+					Expires:  inAnHour,
+					MimeType: "image/jpeg",
 				},
-				Path:     filepath.Join("SampleArtifacts", "b", "c", "d.jpg"),
-				MimeType: "image/jpeg",
+				Path: filepath.Join("SampleArtifacts", "b", "c", "d.jpg"),
 			},
 		})
 }
@@ -278,11 +355,11 @@ func TestDefaultArtifactExpiry(t *testing.T) {
 		[]Artifact{
 			&S3Artifact{
 				BaseArtifact: &BaseArtifact{
-					Name:    "SampleArtifacts/b/c/d.jpg",
-					Expires: inAnHour,
+					Name:     "SampleArtifacts/b/c/d.jpg",
+					Expires:  inAnHour,
+					MimeType: "image/jpeg",
 				},
-				Path:     "SampleArtifacts/b/c/d.jpg",
-				MimeType: "image/jpeg",
+				Path: "SampleArtifacts/b/c/d.jpg",
 			},
 		},
 	)
@@ -328,10 +405,11 @@ func TestMissingArtifactFailsTest(t *testing.T) {
 		Command:    append(helloGoodbye()),
 		MaxRunTime: 30,
 		Artifacts: []struct {
-			Expires tcclient.Time `json:"expires,omitempty"`
-			Name    string        `json:"name,omitempty"`
-			Path    string        `json:"path"`
-			Type    string        `json:"type"`
+			ContentType string        `json:"contentType,omitempty"`
+			Expires     tcclient.Time `json:"expires,omitempty"`
+			Name        string        `json:"name,omitempty"`
+			Path        string        `json:"path"`
+			Type        string        `json:"type"`
 		}{
 			{
 				Path:    "Nonexistent/art i fact.txt",
@@ -365,10 +443,11 @@ func TestProtectedArtifactsReplaced(t *testing.T) {
 		Command:    command,
 		MaxRunTime: 30,
 		Artifacts: []struct {
-			Expires tcclient.Time `json:"expires,omitempty"`
-			Name    string        `json:"name,omitempty"`
-			Path    string        `json:"path"`
-			Type    string        `json:"type"`
+			ContentType string        `json:"contentType,omitempty"`
+			Expires     tcclient.Time `json:"expires,omitempty"`
+			Name        string        `json:"name,omitempty"`
+			Path        string        `json:"path"`
+			Type        string        `json:"type"`
 		}{
 			{
 				Path:    "public/logs/live.log",
@@ -466,10 +545,11 @@ func TestPublicDirectoryArtifact(t *testing.T) {
 		Command:    command,
 		MaxRunTime: 30,
 		Artifacts: []struct {
-			Expires tcclient.Time `json:"expires,omitempty"`
-			Name    string        `json:"name,omitempty"`
-			Path    string        `json:"path"`
-			Type    string        `json:"type"`
+			ContentType string        `json:"contentType,omitempty"`
+			Expires     tcclient.Time `json:"expires,omitempty"`
+			Name        string        `json:"name,omitempty"`
+			Path        string        `json:"path"`
+			Type        string        `json:"type"`
 		}{
 			{
 				Path:    "public",
@@ -520,10 +600,11 @@ func TestConflictingFileArtifactsInPayload(t *testing.T) {
 		Command:    command,
 		MaxRunTime: 30,
 		Artifacts: []struct {
-			Expires tcclient.Time `json:"expires,omitempty"`
-			Name    string        `json:"name,omitempty"`
-			Path    string        `json:"path"`
-			Type    string        `json:"type"`
+			ContentType string        `json:"contentType,omitempty"`
+			Expires     tcclient.Time `json:"expires,omitempty"`
+			Name        string        `json:"name,omitempty"`
+			Path        string        `json:"path"`
+			Type        string        `json:"type"`
 		}{
 			{
 				Path:    "SampleArtifacts/_/X.txt",
@@ -580,10 +661,11 @@ func TestFileArtifactTwiceInPayload(t *testing.T) {
 		Command:    command,
 		MaxRunTime: 30,
 		Artifacts: []struct {
-			Expires tcclient.Time `json:"expires,omitempty"`
-			Name    string        `json:"name,omitempty"`
-			Path    string        `json:"path"`
-			Type    string        `json:"type"`
+			ContentType string        `json:"contentType,omitempty"`
+			Expires     tcclient.Time `json:"expires,omitempty"`
+			Name        string        `json:"name,omitempty"`
+			Path        string        `json:"path"`
+			Type        string        `json:"type"`
 		}{
 			{
 				Path:    "SampleArtifacts/_/X.txt",
@@ -640,10 +722,11 @@ func TestArtifactIncludedAsFileAndDirectoryInPayload(t *testing.T) {
 		Command:    command,
 		MaxRunTime: 30,
 		Artifacts: []struct {
-			Expires tcclient.Time `json:"expires,omitempty"`
-			Name    string        `json:"name,omitempty"`
-			Path    string        `json:"path"`
-			Type    string        `json:"type"`
+			ContentType string        `json:"contentType,omitempty"`
+			Expires     tcclient.Time `json:"expires,omitempty"`
+			Name        string        `json:"name,omitempty"`
+			Path        string        `json:"path"`
+			Type        string        `json:"type"`
 		}{
 			{
 				Path:    "SampleArtifacts/_/X.txt",
@@ -702,10 +785,11 @@ func TestUpload(t *testing.T) {
 		Command:    command,
 		MaxRunTime: 30,
 		Artifacts: []struct {
-			Expires tcclient.Time `json:"expires,omitempty"`
-			Name    string        `json:"name,omitempty"`
-			Path    string        `json:"path"`
-			Type    string        `json:"type"`
+			ContentType string        `json:"contentType,omitempty"`
+			Expires     tcclient.Time `json:"expires,omitempty"`
+			Name        string        `json:"name,omitempty"`
+			Path        string        `json:"path"`
+			Type        string        `json:"type"`
 		}{
 			{
 				Path:    "SampleArtifacts/_/X.txt",
@@ -959,10 +1043,11 @@ func TestFileArtifactHasNoExpiry(t *testing.T) {
 		Command:    copyArtifact("SampleArtifacts/_/X.txt"),
 		MaxRunTime: 30,
 		Artifacts: []struct {
-			Expires tcclient.Time `json:"expires,omitempty"`
-			Name    string        `json:"name,omitempty"`
-			Path    string        `json:"path"`
-			Type    string        `json:"type"`
+			ContentType string        `json:"contentType,omitempty"`
+			Expires     tcclient.Time `json:"expires,omitempty"`
+			Name        string        `json:"name,omitempty"`
+			Path        string        `json:"path"`
+			Type        string        `json:"type"`
 		}{
 			{
 				Path: "SampleArtifacts/_/X.txt",
@@ -1003,10 +1088,11 @@ func TestDirectoryArtifactHasNoExpiry(t *testing.T) {
 		Command:    copyArtifact("SampleArtifacts/_/X.txt"),
 		MaxRunTime: 30,
 		Artifacts: []struct {
-			Expires tcclient.Time `json:"expires,omitempty"`
-			Name    string        `json:"name,omitempty"`
-			Path    string        `json:"path"`
-			Type    string        `json:"type"`
+			ContentType string        `json:"contentType,omitempty"`
+			Expires     tcclient.Time `json:"expires,omitempty"`
+			Name        string        `json:"name,omitempty"`
+			Path        string        `json:"path"`
+			Type        string        `json:"type"`
 		}{
 			{
 				Path: "SampleArtifacts/_",

--- a/generated_all-unix-style.go
+++ b/generated_all-unix-style.go
@@ -40,6 +40,17 @@ type (
 		// `{ "type": "file", "path": "builds\\firefox.exe", "expires": "2015-08-19T17:30:00.000Z" }`
 		Artifacts []struct {
 
+			// Explicitly set the value of the HTTP `Content-Type` response header when the artifact(s)
+			// is/are served over HTTP(S). If not provided (this property is optional) the worker will
+			// guess the content type of artifacts based on the filename extension of the file storing
+			// the artifact content. It does this by looking at the system filename-to-mimetype mappings
+			// defined in multiple `mime.types` files located under `/etc`. Note, setting `contentType`
+			// on a directory artifact will apply the same contentType to all files contained in the
+			// directory.
+			//
+			// See [mime.TypeByExtension](https://godoc.org/mime#TypeByExtension).
+			ContentType string `json:"contentType,omitempty"`
+
 			// Date when artifact should expire must be in the future, no earlier than task deadline, but
 			// no later than task expiry. If not set, defaults to task expiry.
 			Expires tcclient.Time `json:"expires,omitempty"`
@@ -372,6 +383,11 @@ func taskPayloadSchema() string {
       "items": {
         "additionalProperties": false,
         "properties": {
+          "contentType": {
+            "description": "Explicitly set the value of the HTTP ` + "`" + `Content-Type` + "`" + ` response header when the artifact(s)\nis/are served over HTTP(S). If not provided (this property is optional) the worker will\nguess the content type of artifacts based on the filename extension of the file storing\nthe artifact content. It does this by looking at the system filename-to-mimetype mappings\ndefined in multiple ` + "`" + `mime.types` + "`" + ` files located under ` + "`" + `/etc` + "`" + `. Note, setting ` + "`" + `contentType` + "`" + `\non a directory artifact will apply the same contentType to all files contained in the\ndirectory.\n\nSee [mime.TypeByExtension](https://godoc.org/mime#TypeByExtension).",
+            "title": "Content-Type header when serving artifact over HTTP",
+            "type": "string"
+          },
           "expires": {
             "description": "Date when artifact should expire must be in the future, no earlier than task deadline, but\nno later than task expiry. If not set, defaults to task expiry.",
             "format": "date-time",

--- a/generated_windows.go
+++ b/generated_windows.go
@@ -39,6 +39,16 @@ type (
 		// `{ "type": "file", "path": "builds\\firefox.exe", "expires": "2015-08-19T17:30:00.000Z" }`
 		Artifacts []struct {
 
+			// Explicitly set the value of the HTTP `Content-Type` response header when the artifact(s)
+			// is/are served over HTTP(S). If not provided (this property is optional) the worker will
+			// guess the content type of artifacts based on the filename extension of the file storing
+			// the artifact content. It does this by looking at the system filename-to-mimetype mappings
+			// defined in the Windows registry. Note, setting `contentType` on a directory artifact will
+			// apply the same contentType to all files contained in the directory.
+			//
+			// See [mime.TypeByExtension](https://godoc.org/mime#TypeByExtension).
+			ContentType string `json:"contentType,omitempty"`
+
 			// Date when artifact should expire must be in the future, no earlier than task deadline, but
 			// no later than task expiry. If not set, defaults to task expiry.
 			Expires tcclient.Time `json:"expires,omitempty"`
@@ -372,6 +382,11 @@ func taskPayloadSchema() string {
       "items": {
         "additionalProperties": false,
         "properties": {
+          "contentType": {
+            "description": "Explicitly set the value of the HTTP ` + "`" + `Content-Type` + "`" + ` response header when the artifact(s)\nis/are served over HTTP(S). If not provided (this property is optional) the worker will\nguess the content type of artifacts based on the filename extension of the file storing\nthe artifact content. It does this by looking at the system filename-to-mimetype mappings\ndefined in the Windows registry. Note, setting ` + "`" + `contentType` + "`" + ` on a directory artifact will\napply the same contentType to all files contained in the directory.\n\nSee [mime.TypeByExtension](https://godoc.org/mime#TypeByExtension).",
+            "title": "Content-Type header when serving artifact over HTTP",
+            "type": "string"
+          },
           "expires": {
             "description": "Date when artifact should expire must be in the future, no earlier than task deadline, but\nno later than task expiry. If not set, defaults to task expiry.",
             "format": "date-time",

--- a/helper_test.go
+++ b/helper_test.go
@@ -24,10 +24,11 @@ import (
 )
 
 type PayloadArtifact struct {
-	Expires tcclient.Time `json:"expires,omitempty"`
-	Name    string        `json:"name,omitempty"`
-	Path    string        `json:"path"`
-	Type    string        `json:"type"`
+	ContentType string        `json:"contentType,omitempty"`
+	Expires     tcclient.Time `json:"expires,omitempty"`
+	Name        string        `json:"name,omitempty"`
+	Path        string        `json:"path"`
+	Type        string        `json:"type"`
 }
 
 var (

--- a/livelog.go
+++ b/livelog.go
@@ -127,10 +127,10 @@ func (l *LiveLogTask) Stop() *CommandExecutionError {
 			BaseArtifact: &BaseArtifact{
 				Name: livelogName,
 				// same expiry as underlying log it points to
-				Expires: l.task.Definition.Expires,
+				Expires:  l.task.Definition.Expires,
+				MimeType: "text/plain; charset=utf-8",
 			},
-			MimeType: "text/plain; charset=utf-8",
-			URL:      logURL,
+			URL: logURL,
 		},
 	)
 	if err != nil {
@@ -158,10 +158,10 @@ func (l *LiveLogTask) uploadLiveLog() error {
 			BaseArtifact: &BaseArtifact{
 				Name: livelogName,
 				// livelog expires when task must have completed
-				Expires: tcclient.Time(maxRunTimeDeadline),
+				Expires:  tcclient.Time(maxRunTimeDeadline),
+				MimeType: "text/plain; charset=utf-8",
 			},
-			MimeType: "text/plain; charset=utf-8",
-			URL:      getURL.String(),
+			URL: getURL.String(),
 		},
 	)
 	if uploadErr != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -55,6 +55,9 @@ func TestAbortAfterMaxRunTime(t *testing.T) {
 	if !strings.Contains(logtext, "max run time exceeded") {
 		t.Fatalf("Was expecting log file to mention task abortion, but it doesn't")
 	}
+	// TODO: this is a hack to make sure sleep process has died before we call teardown
+	// We need to make sure processes are properly killed when a task is aborted
+	time.Sleep(1500 * time.Millisecond)
 }
 
 func TestIdleWithoutCrash(t *testing.T) {

--- a/supersede.go
+++ b/supersede.go
@@ -94,12 +94,12 @@ func (l *SupersedeTask) Start() *CommandExecutionError {
 		e := l.task.uploadArtifact(
 			&S3Artifact{
 				BaseArtifact: &BaseArtifact{
-					Name:    supersededByName,
-					Expires: l.task.Definition.Expires,
+					Name:     supersededByName,
+					Expires:  l.task.Definition.Expires,
+					MimeType: "application/json",
 				},
 				Path:            supersededByPath,
 				ContentEncoding: "gzip",
-				MimeType:        "application/json",
 			},
 		)
 		if e != nil {

--- a/taskstatus_test.go
+++ b/taskstatus_test.go
@@ -16,10 +16,11 @@ func TestResolveResolvedTask(t *testing.T) {
 		Command:    goRun("resolvetask.go"),
 		MaxRunTime: 60,
 		Artifacts: []struct {
-			Expires tcclient.Time `json:"expires,omitempty"`
-			Name    string        `json:"name,omitempty"`
-			Path    string        `json:"path"`
-			Type    string        `json:"type"`
+			ContentType string        `json:"contentType,omitempty"`
+			Expires     tcclient.Time `json:"expires,omitempty"`
+			Name        string        `json:"name,omitempty"`
+			Path        string        `json:"path"`
+			Type        string        `json:"type"`
 		}{
 
 			{

--- a/windows.yml
+++ b/windows.yml
@@ -78,6 +78,18 @@ properties:
           description: |-
             Date when artifact should expire must be in the future, no earlier than task deadline, but
             no later than task expiry. If not set, defaults to task expiry.
+        contentType:
+          title: Content-Type header when serving artifact over HTTP
+          type: string
+          description: |-
+            Explicitly set the value of the HTTP `Content-Type` response header when the artifact(s)
+            is/are served over HTTP(S). If not provided (this property is optional) the worker will
+            guess the content type of artifacts based on the filename extension of the file storing
+            the artifact content. It does this by looking at the system filename-to-mimetype mappings
+            defined in the Windows registry. Note, setting `contentType` on a directory artifact will
+            apply the same contentType to all files contained in the directory.
+
+            See [mime.TypeByExtension](https://godoc.org/mime#TypeByExtension).
       required:
       - type
       - path


### PR DESCRIPTION
This should allow people to explicitly set `Content-Type` of artifact resources if they are not happy with the default choice of the system.