### PR TITLE
Bug 1333957 - differentiate error and info log lines

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -74,7 +74,7 @@ func (base *BaseArtifact) Base() *BaseArtifact {
 }
 
 func (artifact *RedirectArtifact) ProcessResponse(response interface{}, task *TaskRun) error {
-	task.Logf("Uploading redirect artifact %v to URL %v with mime type %q and expiry %v", artifact.Name, artifact.URL, artifact.ContentType, artifact.Expires)
+	task.Infof("Uploading redirect artifact %v to URL %v with mime type %q and expiry %v", artifact.Name, artifact.URL, artifact.ContentType, artifact.Expires)
 	// nothing to do
 	return nil
 }
@@ -93,7 +93,7 @@ func (redirectArtifact *RedirectArtifact) ResponseObject() interface{} {
 }
 
 func (artifact *ErrorArtifact) ProcessResponse(response interface{}, task *TaskRun) error {
-	task.Logf("Uploading error artifact %v from file %v with message %q, reason %q and expiry %v", artifact.Name, artifact.Path, artifact.Message, artifact.Reason, artifact.Expires)
+	task.Errorf("Uploading error artifact %v from file %v with message %q, reason %q and expiry %v", artifact.Name, artifact.Path, artifact.Message, artifact.Reason, artifact.Expires)
 	// TODO: process error response
 	return nil
 }
@@ -183,7 +183,7 @@ func (artifact *S3Artifact) ProcessResponse(resp interface{}, task *TaskRun) (er
 	response := resp.(*queue.S3ArtifactResponse)
 
 	artifact.ChooseContentEncoding()
-	task.Logf("Uploading artifact %v from file %v with content encoding %q, mime type %q and expiry %v", artifact.Name, artifact.Path, artifact.ContentEncoding, artifact.ContentType, artifact.Expires)
+	task.Infof("Uploading artifact %v from file %v with content encoding %q, mime type %q and expiry %v", artifact.Name, artifact.Path, artifact.ContentEncoding, artifact.ContentType, artifact.Expires)
 	transferContentFile := artifact.CreateTempFileForPUTBody()
 	defer os.Remove(transferContentFile)
 
@@ -480,7 +480,7 @@ func (task *TaskRun) uploadArtifact(artifact Artifact) *CommandExecutionError {
 	e = artifact.ProcessResponse(resp, task)
 	// note: this only returns an error, if ProcessResponse returns an error...
 	if e != nil {
-		task.Logf("Error uploading artifact: %v", e)
+		task.Errorf("Error uploading artifact: %v", e)
 	}
 	return ResourceUnavailable(e)
 }

--- a/main.go
+++ b/main.go
@@ -887,6 +887,10 @@ func (task *TaskRun) Infof(format string, v ...interface{}) {
 	task.Info(fmt.Sprintf(format, v...))
 }
 
+func (task *TaskRun) Warnf(format string, v ...interface{}) {
+	task.Warn(fmt.Sprintf(format, v...))
+}
+
 func (task *TaskRun) Errorf(format string, v ...interface{}) {
 	task.Error(fmt.Sprintf(format, v...))
 }
@@ -894,6 +898,11 @@ func (task *TaskRun) Errorf(format string, v ...interface{}) {
 func (task *TaskRun) Info(message string) {
 	now := tcclient.Time(time.Now()).String()
 	task.Log("[taskcluster "+now+"] ", message)
+}
+
+func (task *TaskRun) Warn(message string) {
+	now := tcclient.Time(time.Now()).String()
+	task.Log("[taskcluster:warn "+now+"] ", message)
 }
 
 func (task *TaskRun) Error(message string) {
@@ -1153,7 +1162,7 @@ func (task *TaskRun) Run() (err *executionErrors) {
 			// public/ directory artifact that includes
 			// public/logs/live_backing.log inadvertently.
 			if feature := task.featureArtifacts[artifact.Base().Name]; feature != "" {
-				task.Infof("WARNING - not uploading artifact %v found in task.payload.artifacts section, since this will be uploaded later by %v", artifact.Base().Name, feature)
+				task.Warnf("Not uploading artifact %v found in task.payload.artifacts section, since this will be uploaded later by %v", artifact.Base().Name, feature)
 				continue
 			}
 			err.add(task.uploadArtifact(artifact))

--- a/main_test.go
+++ b/main_test.go
@@ -103,27 +103,39 @@ func TestLogFormat(t *testing.T) {
 	testCases := []LogFormatTest{
 		LogFormatTest{
 			LogCall: func() {
-				tr.Info("Another day for you and me in paradise.")
+				tr.Info("Another day for you and me in paradise")
 			},
-			ResultFormat: `^\[taskcluster 20\d{2}-[01]\d-[0123]\dT[012]\d:[012345]\d:[012345]\d\.\d{3}Z\] Another day for you and me in paradise.` + "\n$",
+			ResultFormat: `^\[taskcluster 20\d{2}-[01]\d-[0123]\dT[012]\d:[012345]\d:[012345]\d\.\d{3}Z\] Another day for you and me in paradise` + "\n$",
 		},
 		LogFormatTest{
 			LogCall: func() {
-				tr.Error("Well lawdy, lawdy, lawdy Miss Clawdy.")
+				tr.Warn("I believe in a thing called love")
 			},
-			ResultFormat: `^\[taskcluster:error\] Well lawdy, lawdy, lawdy Miss Clawdy.` + "\n$",
+			ResultFormat: `^\[taskcluster:warn 20\d{2}-[01]\d-[0123]\dT[012]\d:[012345]\d:[012345]\d\.\d{3}Z\] I believe in a thing called love` + "\n$",
 		},
 		LogFormatTest{
 			LogCall: func() {
-				tr.Infof("It only takes a minute %v.", "girl")
+				tr.Error("Well lawdy, lawdy, lawdy Miss Clawdy")
 			},
-			ResultFormat: `^\[taskcluster 20\d{2}-[01]\d-[0123]\dT[012]\d:[012345]\d:[012345]\d\.\d{3}Z\] It only takes a minute girl.` + "\n$",
+			ResultFormat: `^\[taskcluster:error\] Well lawdy, lawdy, lawdy Miss Clawdy` + "\n$",
 		},
 		LogFormatTest{
 			LogCall: func() {
-				tr.Errorf("Thought I saw a man %v to life.", "brought")
+				tr.Infof("It only takes a minute %v", "girl")
 			},
-			ResultFormat: `^\[taskcluster:error\] Thought I saw a man brought to life.` + "\n$",
+			ResultFormat: `^\[taskcluster 20\d{2}-[01]\d-[0123]\dT[012]\d:[012345]\d:[012345]\d\.\d{3}Z\] It only takes a minute girl` + "\n$",
+		},
+		LogFormatTest{
+			LogCall: func() {
+				tr.Warnf("When you %v %v best, but you don't succeed", "try", "your")
+			},
+			ResultFormat: `^\[taskcluster:warn 20\d{2}-[01]\d-[0123]\dT[012]\d:[012345]\d:[012345]\d\.\d{3}Z\] When you try your best, but you don't succeed` + "\n$",
+		},
+		LogFormatTest{
+			LogCall: func() {
+				tr.Errorf("Thought I saw a man %v to life", "brought")
+			},
+			ResultFormat: `^\[taskcluster:error\] Thought I saw a man brought to life` + "\n$",
 		},
 	}
 	for _, test := range testCases {

--- a/mounts.go
+++ b/mounts.go
@@ -329,8 +329,8 @@ func (taskMount *TaskMount) Start() *CommandExecutionError {
 	// services has an outage. Although 1) could not be part of an obscure
 	// attack strategy (although releases shouldn't use caches).
 	if err != nil {
-		taskMount.task.Error("WARNING: Could not reach purgecache service to see if caches need purging!")
-		taskMount.task.Error(err.Error())
+		taskMount.task.Warn("Could not reach purgecache service to see if caches need purging!")
+		taskMount.task.Warn(err.Error())
 	}
 	// loop through all mounts described in payload
 	for _, mount := range taskMount.mounts {

--- a/mounts.go
+++ b/mounts.go
@@ -329,8 +329,8 @@ func (taskMount *TaskMount) Start() *CommandExecutionError {
 	// services has an outage. Although 1) could not be part of an obscure
 	// attack strategy (although releases shouldn't use caches).
 	if err != nil {
-		taskMount.task.Log("WARNING: Could not reach purgecache service to see if caches need purging!")
-		taskMount.task.Log(err.Error())
+		taskMount.task.Error("WARNING: Could not reach purgecache service to see if caches need purging!")
+		taskMount.task.Error(err.Error())
 	}
 	// loop through all mounts described in payload
 	for _, mount := range taskMount.mounts {

--- a/os_groups.go
+++ b/os_groups.go
@@ -51,13 +51,13 @@ func (osGroups *OSGroups) Start() (err *CommandExecutionError) {
 	groups := osGroups.Task.Payload.OSGroups
 	if config.RunTasksAsCurrentUser {
 		if len(groups) > 0 {
-			osGroups.Task.Logf("Not adding user to groups %v since we are running as current user.", groups)
+			osGroups.Task.Infof("Not adding user to groups %v since we are running as current user.", groups)
 		}
 		return nil
 	}
 	err = MalformedPayloadError(osGroups.Task.addGroupsToUser(groups))
 	if err != nil {
-		osGroups.Task.Logf("Could not add os group(s) to task user: %v\n%v", groups, err)
+		osGroups.Task.Errorf("Could not add os group(s) to task user: %v\n%v", groups, err)
 	}
 	return
 }

--- a/plat_windows.go
+++ b/plat_windows.go
@@ -217,7 +217,7 @@ func (task *TaskRun) generateCommand(index int) error {
 	if !config.RunTasksAsCurrentUser {
 		hToken, err := win32.InteractiveUserToken(time.Minute)
 		if err != nil {
-			task.Log("Cannot get handle of interactive user")
+			task.Error("Cannot get handle of interactive user")
 			return err
 		}
 		loginInfo.HUser = hToken

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -20,7 +20,7 @@ const (
 	CRASH                 = Verdict(2)
 	TIME_LIMIT_EXCEEDED   = Verdict(3)
 	MEMORY_LIMIT_EXCEEDED = Verdict(4)
-	IDLE                  = Verdict(5)
+	MAX_RUNTIME_EXCEEDED  = Verdict(5)
 	SECURITY_VIOLATION    = Verdict(6)
 )
 
@@ -36,8 +36,8 @@ func (v Verdict) String() string {
 		return "TIME_LIMIT_EXCEEDED"
 	case MEMORY_LIMIT_EXCEEDED:
 		return "MEMORY_LIMIT_EXCEEDED"
-	case IDLE:
-		return "IDLENESS_LIMIT_EXCEEDED"
+	case MAX_RUNTIME_EXCEEDED:
+		return "MAX_RUNTIME_EXCEEDED"
 	case SECURITY_VIOLATION:
 		return "SECURITY_VIOLATION"
 	}
@@ -53,7 +53,7 @@ func GetVerdict(r *Result) Verdict {
 	case r.SuccessCode&(subprocess.EF_PROCESS_LIMIT_HIT|subprocess.EF_PROCESS_LIMIT_HIT_POST) != 0:
 		return SECURITY_VIOLATION
 	case r.SuccessCode&(subprocess.EF_INACTIVE|subprocess.EF_TIME_LIMIT_HARD) != 0:
-		return IDLE
+		return MAX_RUNTIME_EXCEEDED
 	case r.SuccessCode&(subprocess.EF_TIME_LIMIT_HIT|subprocess.EF_TIME_LIMIT_HIT_POST) != 0:
 		return TIME_LIMIT_EXCEEDED
 	case r.SuccessCode&(subprocess.EF_MEMORY_LIMIT_HIT|subprocess.EF_MEMORY_LIMIT_HIT_POST) != 0:

--- a/supersede.go
+++ b/supersede.go
@@ -68,8 +68,8 @@ func (l *SupersedeTask) Start() *CommandExecutionError {
 	resp, _, err := httpbackoff.Get(supersederURL)
 	if err != nil {
 		// if problem with superseder service, let's run all tasks, and not resolve them all as exception
-		l.task.Infof("WARNING: problem accessing supersederUrl: %v", err)
-		l.task.Info("Not able to see if this task has been superseded!")
+		l.task.Warnf("Problem accessing supersederUrl: %v", err)
+		l.task.Warn("Not able to see if this task has been superseded!")
 		return nil
 	}
 	decoder := json.NewDecoder(resp.Body)
@@ -77,8 +77,8 @@ func (l *SupersedeTask) Start() *CommandExecutionError {
 	err = decoder.Decode(&supersedes)
 	if err != nil {
 		// if problem with superseder service, let's run all tasks, and not resolve them all as exception
-		l.task.Infof("WARNING: not able to interpret response from supersederUrl %v as json list of task IDs: %v", supersederURL, err)
-		l.task.Infof("Not able to see if this task has been superseded!")
+		l.task.Warnf("Not able to interpret response from supersederUrl %v as json list of task IDs: %v", supersederURL, err)
+		l.task.Warn("Not able to see if this task has been superseded!")
 		return nil
 	}
 	taskIDs := supersedes.TaskIDs

--- a/supersede.go
+++ b/supersede.go
@@ -68,8 +68,8 @@ func (l *SupersedeTask) Start() *CommandExecutionError {
 	resp, _, err := httpbackoff.Get(supersederURL)
 	if err != nil {
 		// if problem with superseder service, let's run all tasks, and not resolve them all as exception
-		l.task.Logf("WARNING: problem accessing supersederUrl: %v", err)
-		l.task.Log("Not able to see if this task has been superseded!")
+		l.task.Infof("WARNING: problem accessing supersederUrl: %v", err)
+		l.task.Info("Not able to see if this task has been superseded!")
 		return nil
 	}
 	decoder := json.NewDecoder(resp.Body)
@@ -77,8 +77,8 @@ func (l *SupersedeTask) Start() *CommandExecutionError {
 	err = decoder.Decode(&supersedes)
 	if err != nil {
 		// if problem with superseder service, let's run all tasks, and not resolve them all as exception
-		l.task.Logf("WARNING: not able to interpret response from supersederUrl %v as json list of task IDs: %v", supersederURL, err)
-		l.task.Logf("Not able to see if this task has been superseded!")
+		l.task.Infof("WARNING: not able to interpret response from supersederUrl %v as json list of task IDs: %v", supersederURL, err)
+		l.task.Infof("Not able to see if this task has been superseded!")
 		return nil
 	}
 	taskIDs := supersedes.TaskIDs

--- a/taskstatus.go
+++ b/taskstatus.go
@@ -147,7 +147,7 @@ func (tsm *TaskStatusManager) Abort() error {
 		aborted,
 		func(task *TaskRun) error {
 			log.Printf("Aborting task %v - max run time exceeded!", task.TaskID)
-			task.Log("Aborting task - max run time exceeded!")
+			task.Error("Aborting task - max run time exceeded!")
 			// defer func() {
 			// 	if r := recover(); r != nil {
 			// 		log.Printf("Panic occured when killing process - ignoring!\n%v", r)


### PR DESCRIPTION
I've split up each of the two task logging methods into a pair of Info / Error methods, to distinguish if they are error lines or info lines:

```
task.Log(...)
  -> task.Info(...)
  -> task.Error(...)

task.Logf(...)
  -> task.Infof(...)
  -> task.Errorf(...)
```

Then in each logging call, I've made an executive decision about if it is an info or an error log message.

In line with [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1333957#c12) error logs are now written like:

```
[taskcluster:error] <message>
```

Info log messages are written like:

```
[taskcluster <timestamp>] <message>
```

This is likely to be updated later to provide a timestamp in the error message too, but for now this would break treeherder log parsing, so will only be done once treeherder can accept the input.

I've added tests to ensure the logging is as treeherder expects.