### PR TITLE
Bug 1358545 - check file permissions of chain of trust key and validity of content on startup

### DIFF
--- a/chain_of_trust_all-unix-style.go
+++ b/chain_of_trust_all-unix-style.go
@@ -1,0 +1,55 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+
+	"github.com/taskcluster/generic-worker/process"
+)
+
+func (cot *ChainOfTrustTaskFeature) ensureTaskUserCantReadPrivateCotKey() error {
+	c, err := process.NewCommand([]string{"/bin/cat", config.SigningKeyLocation}, cwd, cot.task.EnvVars())
+	if err != nil {
+		panic(fmt.Errorf("SERIOUS BUG: Could not create command (not even trying to execute it yet) to cat private chain of trust key - %v", err))
+	}
+	r := c.Execute()
+	if !r.Failed() {
+		return fmt.Errorf(ChainOfTrustKeyNotSecureMessage)
+	}
+	return nil
+}
+
+// Take ownership of private signing key, and then give it 0600 file permissions
+func secureSigningKey() (err error) {
+	var currentUser *user.User
+	currentUser, err = user.Current()
+	if err != nil {
+		return err
+	}
+	var uid, gid int
+	uid, err = strconv.Atoi(currentUser.Uid)
+	if err != nil {
+		return err
+	}
+	gid, err = strconv.Atoi(currentUser.Gid)
+	if err != nil {
+		return err
+	}
+	err = os.Chown(
+		config.SigningKeyLocation,
+		uid,
+		gid,
+	)
+	if err != nil {
+		return err
+	}
+	err = os.Chmod(
+		config.SigningKeyLocation,
+		0600,
+	)
+	return
+}

--- a/chain_of_trust_windows.go
+++ b/chain_of_trust_windows.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"golang.org/x/sys/windows"
+
+	acl "github.com/hectane/go-acl"
+	"github.com/taskcluster/generic-worker/process"
+)
+
+func (cot *ChainOfTrustTaskFeature) ensureTaskUserCantReadPrivateCotKey() error {
+	loginInfo, err := TaskUserLoginInfo()
+	if err != nil {
+		panic(fmt.Errorf("SERIOUS BUG: Could not get login info of task user to check it can't read chain of trust private key - %v", err))
+	}
+	TenSecondDeadline := time.Now().Add(time.Second * 10)
+	commandLine := `cmd.exe /c type "` + config.SigningKeyLocation + `"`
+	c, err := process.NewCommand(loginInfo, nil, &commandLine, &cwd, nil, TenSecondDeadline)
+	if err != nil {
+		panic(fmt.Errorf("SERIOUS BUG: Could not create command (not even trying to execute it yet) to cat private chain of trust key - %v", err))
+	}
+	r := c.Execute()
+	if !r.Failed() {
+		log.Print(r.String())
+		return fmt.Errorf(ChainOfTrustKeyNotSecureMessage)
+	}
+	return nil
+}
+
+// Ensure only administrators have access permissions for the chain of trust
+// private signing key file, and grant them full control.
+func secureSigningKey() (err error) {
+	err = acl.Apply(
+
+		// Private signing key file
+		config.SigningKeyLocation,
+		// delete existing permissions (ACLs)
+		true,
+		// don't inherit permissions (ACLs)
+		false,
+		// grant Administrators group full control
+		acl.GrantName(windows.GENERIC_ALL, "Administrators"),
+	)
+	return
+}

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -143,7 +143,7 @@ func (c *Command) Execute() (r *Result) {
 	}
 }
 
-func NewCommand(loginInfo *subprocess.LoginInfo, commandLine string, workingDirectory *string, env *[]string, deadline time.Time) (*Command, error) {
+func NewCommand(loginInfo *subprocess.LoginInfo, applicationName *string, commandLine *string, workingDirectory *string, env *[]string, deadline time.Time) (*Command, error) {
 	if deadline.IsZero() {
 		log.Print("No deadline!")
 	} else {
@@ -153,9 +153,9 @@ func NewCommand(loginInfo *subprocess.LoginInfo, commandLine string, workingDire
 		Subprocess: &subprocess.Subprocess{
 			TimeQuantum: time.Second / 4,
 			Cmd: &subprocess.CommandLine{
-				ApplicationName: nil,
-				CommandLine:     &commandLine,
-				Parameters:      nil,
+				ApplicationName: applicationName,
+				CommandLine:     commandLine,
+				Parameters:      nil, // unused on windows
 			},
 			CurrentDirectory:    workingDirectory,
 			TimeLimit:           0,
@@ -179,7 +179,7 @@ func NewCommand(loginInfo *subprocess.LoginInfo, commandLine string, workingDire
 		},
 		Deadline: deadline,
 	}
-	log.Printf("Created command: %v", commandLine)
+	log.Printf("Created command: %v to run from folder %v", *commandLine, *workingDirectory)
 	return command, nil
 }
 


### PR DESCRIPTION
1) Don't start worker if the chain of trust key cannot be read or has invalid content.
2) Don't start the worker if the chain of trust key can be read by a task user.