### PR TITLE
Bug 1441482 - free up disk space between tasks, not after task claim

### DIFF
--- a/main.go
+++ b/main.go
@@ -608,9 +608,17 @@ func RunWorker() (exitCode ExitCode) {
 				return NONCURRENT_DEPLOYMENT_ID
 			}
 		}
-		// make sure at least 5 seconds passes between iterations
-		wait5Seconds := time.NewTimer(time.Second * 5)
+
+		// Ensure there is enough disk space *before* claiming a task
+		err := garbageCollection()
+		if err != nil {
+			panic(err)
+		}
+
 		task := ClaimWork()
+
+		// make sure at least 5 seconds pass between queue.claimWork API calls
+		wait5Seconds := time.NewTimer(time.Second * 5)
 
 		if task != nil {
 			errors := task.Run()

--- a/mounts.go
+++ b/mounts.go
@@ -308,18 +308,9 @@ func (taskMount *TaskMount) Start() *CommandExecutionError {
 	if taskMount.payloadError != nil {
 		return MalformedPayloadError(taskMount.payloadError)
 	}
-	// Let's perform a garbage collection here before running the task. In
-	// taskcluster-worker this will run in its own thread, and here it only
-	// works as we have a single job running at a time, so we don't need to
-	// worry about concurrency etc. But it is ugly to do it here, but
-	// sufficient for generic worker.
-	err := garbageCollection()
-	if err != nil {
-		panic(err)
-	}
 	// Check if any caches need to be purged. See:
 	//   https://docs.taskcluster.net/reference/core/purge-cache
-	err = taskMount.purgeCaches()
+	err := taskMount.purgeCaches()
 	// Two possible strategies if we can't reach purgecache service:
 	//
 	//   1) be optimistic, assume caches are ok, and don't purge them


### PR DESCRIPTION
Currently the purging of caches is the responsibility of the `MountsFeature`. Unfortunately, features operate on claimed tasks, so in the current implementation, a task is claimed before the feature has had a chance to see if it can free up enough disk space for the task. When it becomes unable to execute the task, because it lacks disk space, it has no choice but to resolve the task with the exception state.

This PR moves the purging of caches outside of the feature, into the generic worker task claim loop, immediately before a task is claimed. This way, the worker knows ahead of time that it won't be able to claim a task, and is able to exit gracefully, without sacrificing any task runs on the way.

The reason it was originally implented like this, was to localise the management of caches to the feature that used them, and not dirty the core worker with these concerns.

With this change, the generic-worker runtime now concerns itself with resource purging, but this probably isn't such a bad thing. In future, perhaps other features will want to register resources with the worker, and allow the worker to take care of purging them.