### PR TITLE
Bug 1447265 - use os/exec package on Windows too

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${0}")"
 # https://bugzil.la/1441889 is resolved, and travis-ci.org works correctly with
 # go 1.10 (currently, if you specify go 1.10, you get go 1.1).
 GO_MAJOR_VERSION=1
-MIN_GO_MINOR_VERSION=9
+MIN_GO_MINOR_VERSION=10
 
 unset CGO_ENABLED
 unset GOOS

--- a/chain_of_trust_windows.go
+++ b/chain_of_trust_windows.go
@@ -17,8 +17,7 @@ func (cot *ChainOfTrustTaskFeature) ensureTaskUserCantReadPrivateCotKey() error 
 		panic(fmt.Errorf("SERIOUS BUG: Could not get login info of task user to check it can't read chain of trust private key - %v", err))
 	}
 	TenSecondDeadline := time.Now().Add(time.Second * 10)
-	commandLine := `cmd.exe /c type "` + config.SigningKeyLocation + `"`
-	c, err := process.NewCommand(loginInfo, nil, &commandLine, &cwd, nil, TenSecondDeadline)
+	c, err := process.NewCommand([]string{"cmd.exe", "/c", "type", config.SigningKeyLocation}, cwd, nil, loginInfo, TenSecondDeadline)
 	if err != nil {
 		panic(fmt.Errorf("SERIOUS BUG: Could not create command (not even trying to execute it yet) to cat private chain of trust key - %v", err))
 	}

--- a/plat_windows.go
+++ b/plat_windows.go
@@ -127,7 +127,7 @@ func prepareTaskUser(userName string) (reboot bool) {
 		}
 		if script := config.RunAfterUserCreation; script != "" {
 			var noDeadline time.Time
-			command, err := process.NewCommand(loginInfo, nil, &script, &taskContext.TaskDir, nil, noDeadline)
+			command, err := process.NewCommand([]string{script}, taskContext.TaskDir, nil, loginInfo, noDeadline)
 			if err != nil {
 				panic(err)
 			}
@@ -218,7 +218,7 @@ func (task *TaskRun) generateCommand(index int) error {
 		task.Errorf("Cannot get handle of interactive user: %v", err)
 		return err
 	}
-	command, err := process.NewCommand(loginInfo, nil, &wrapper, &taskContext.TaskDir, nil, task.maxRunTimeDeadline)
+	command, err := process.NewCommand([]string{wrapper}, taskContext.TaskDir, nil, loginInfo, task.maxRunTimeDeadline)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Now go 1.10 supports running processes using `CreateProcessAsUser` on Windows in the standard library, so this PR uses it.