### PR TITLE
Move task reclaims into TaskStatusManager

### DIFF
--- a/livelog.go
+++ b/livelog.go
@@ -69,7 +69,7 @@ func (l *LiveLogTask) RequiredScopes() scopes.Required {
 func (l *LiveLogTask) Start() *CommandExecutionError {
 	liveLog, err := livelog.New(config.LiveLogExecutable, config.LiveLogCertificate, config.LiveLogKey, config.LiveLogPUTPort, config.LiveLogGETPort)
 	if err != nil {
-		log.Printf("WARN: could not create livelog: %s", err)
+		log.Printf("WARNING: could not create livelog: %s", err)
 		// then run without livelog, is only a "best effort" service
 		return nil
 	}
@@ -81,7 +81,7 @@ func (l *LiveLogTask) Start() *CommandExecutionError {
 
 	err = l.uploadLiveLog()
 	if err != nil {
-		log.Printf("WARN: could not upload livelog: %s", err)
+		log.Printf("WARNING: could not upload livelog: %s", err)
 	}
 	return nil
 }
@@ -123,12 +123,12 @@ func (l *LiveLogTask) Stop() *CommandExecutionError {
 	errClose := l.liveLog.LogWriter.Close()
 	if errClose != nil {
 		// no need to raise an exception
-		log.Printf("WARN: could not close livelog writer: %s", errClose)
+		log.Printf("WARNING: could not close livelog writer: %s", errClose)
 	}
 	errTerminate := l.liveLog.Terminate()
 	if errTerminate != nil {
 		// no need to raise an exception
-		log.Printf("WARN: could not terminate livelog writer: %s", errTerminate)
+		log.Printf("WARNING: could not terminate livelog writer: %s", errTerminate)
 	}
 	log.Printf("Redirecting %v to %v", livelogName, logName)
 	logURL := fmt.Sprintf("%v/task/%v/runs/%v/artifacts/%v", queue.BaseURL, l.task.TaskID, l.task.RunID, logName)

--- a/model.go
+++ b/model.go
@@ -43,7 +43,6 @@ type (
 		// be useful for the user. Normally this map would get appended to by
 		// features when they are started.
 		featureArtifacts map[string]string
-		reclaimMux       sync.Mutex
 	}
 
 	S3ArtifactResponse struct {

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -167,11 +167,19 @@ func (c *Command) Kill() (killOutput []byte, err error) {
 		// If process hasn't been started yet, nothing to kill
 		return []byte{}, nil
 	}
+	// Concurrent access to c.ProcessState is not thread safe - so let's not do this.
+	// Need to find a better way to manage this...
+	// if c.ProcessState != nil {
+	// 	// If process has finished, nothing to kill
+	// 	return
+	// }
 	c.Aborted = true
 	log.Printf("Killing process tree with parent PID %v... (%p)", c.Process.Pid, c)
-	defer log.Printf("Process tree with parent PID %v killed.", c.Process.Pid)
+	defer log.Printf("taskkill.exe command has completed for PID %v", c.Process.Pid)
 	// here we use taskkill.exe rather than c.Process.Kill() since we want child processes also to be killed
-	return exec.Command("taskkill.exe", "/pid", strconv.Itoa(c.Process.Pid), "/f", "/t").CombinedOutput()
+	bytes, err := exec.Command("taskkill.exe", "/pid", strconv.Itoa(c.Process.Pid), "/f", "/t").CombinedOutput()
+	log.Print("taskkill.exe output:\n" + string(bytes))
+	return bytes, err
 }
 
 type LogonSession struct {

--- a/taskcluster_proxy.go
+++ b/taskcluster_proxy.go
@@ -107,7 +107,7 @@ func (l *TaskclusterProxyTask) Stop() *CommandExecutionError {
 	if errTerminate != nil {
 		// no need to raise an exception, machine will reboot anyway
 		l.task.Warnf("[taskcluster-proxy] Could not terminate taskcluster proxy process: %s", errTerminate)
-		log.Printf("WARN: could not terminate taskcluster proxy writer: %s", errTerminate)
+		log.Printf("WARNING: could not terminate taskcluster proxy writer: %s", errTerminate)
 	}
 	return nil
 }

--- a/taskstatus.go
+++ b/taskstatus.go
@@ -309,10 +309,7 @@ func NewTaskStatusManager(task *TaskRun) *TaskStatusManager {
 	// attempted a few minutes prior to expiration, to allow for clock drift.
 
 	go func() {
-		defer func() {
-			tsm.finishedReclaiming = true
-			close(tsm.reclaimingDone)
-		}()
+		defer close(tsm.reclaimingDone)
 		for {
 			var waitTimeUntilReclaim time.Duration
 			if reclaimEvery5Seconds {
@@ -350,10 +347,11 @@ func NewTaskStatusManager(task *TaskRun) *TaskStatusManager {
 	return tsm
 }
 
-// stopReclaiming must be called when tsm.Lock() is held by caller
+// stopReclaims() must be called when tsm.Lock() is held by caller
 func (tsm *TaskStatusManager) stopReclaims() {
 	if !tsm.finishedReclaiming {
 		close(tsm.stopReclaiming)
 		<-tsm.reclaimingDone
+		tsm.finishedReclaiming = true
 	}
 }

--- a/taskstatus.go
+++ b/taskstatus.go
@@ -52,7 +52,7 @@ type TaskStatusManager struct {
 	stopReclaiming chan struct{}
 	// closed when reclaim loop exits
 	reclaimingDone chan struct{}
-	// true if task completed, failed, errored or was aborted
+	// true if reclaims are no longer taking place for this task
 	finishedReclaiming bool
 }
 

--- a/taskstatus.go
+++ b/taskstatus.go
@@ -317,7 +317,7 @@ func NewTaskStatusManager(task *TaskRun) *TaskStatusManager {
 				waitTimeUntilReclaim = time.Second * 5
 			} else {
 				// Reclaim 3 mins before current claim expires...
-				takenUntil := time.Time(task.StatusManager.TakenUntil())
+				takenUntil := time.Time(tsm.TakenUntil())
 				reclaimTime := takenUntil.Add(time.Minute * -3)
 				// Round(0) forces wall time calculation instead of monotonic time in case machine slept etc
 				waitTimeUntilReclaim = reclaimTime.Round(0).Sub(time.Now())
@@ -335,7 +335,7 @@ func NewTaskStatusManager(task *TaskRun) *TaskStatusManager {
 				return
 			case <-time.After(waitTimeUntilReclaim):
 				log.Printf("About to reclaim task %v...", task.TaskID)
-				err := task.StatusManager.reclaim()
+				err := tsm.reclaim()
 				if err != nil {
 					log.Printf("ERROR: Encountered exception when reclaiming task %v - giving up retrying: %v", task.TaskID, err)
 					return

--- a/taskstatus.go
+++ b/taskstatus.go
@@ -190,7 +190,6 @@ func (tsm *TaskStatusManager) Abort(cee *CommandExecutionError) error {
 	return tsm.updateStatus(
 		aborted,
 		func(task *TaskRun) error {
-			tsm.stopReclaims()
 			task.Errorf("Aborting task...")
 			task.kill()
 			tsm.abortException = cee


### PR DESCRIPTION
This is a cleanup of the reclaim logic, to put it all in the `TaskStatusManager`. Callers don't need to concern themselves with reclaims, when you create the `TaskStatusManager`, it now starts the reclaims in a private (non-exported) background go routine. When a task is aborted or completes naturally, the reclaiming automatically stops.