### PR TITLE
Bug 1465479 - Don't block task abortion waiting for cmd.Wait() to complete

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -171,8 +171,7 @@ tasks:
         - go get -v -u
         - cd ..
         - go generate
-        # getting the real revision has proven difficult on win7 32 bit, so a fake one is good enough for these builds
-        - set revision=0123456789012345678901234567890123456789
+        - set revision={{ event.head.sha }}
         - go get -ldflags "-X main.revision=%revision%" -v -u -t ./...
         - set GORACE=history_size=7
         - C:\generic-worker\generic-worker-test-creds.cmd

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -21,7 +21,7 @@ import (
 var (
 	// all tests can share taskGroupId so we can view all test tasks in same
 	// graph later for troubleshooting
-	taskGroupID string = slugid.Nice()
+	taskGroupID = slugid.Nice()
 )
 
 func validateArtifacts(
@@ -406,12 +406,12 @@ func TestProtectedArtifactsReplaced(t *testing.T) {
 	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
 
 	command := helloGoodbye()
-	command = append(command, copyArtifactTo("SampleArtifacts/_/X.txt", "public/logs/live.log")...)
-	command = append(command, copyArtifactTo("SampleArtifacts/_/X.txt", "public/logs/live_backing.log")...)
-	command = append(command, copyArtifactTo("SampleArtifacts/_/X.txt", "public/logs/certified.log")...)
-	command = append(command, copyArtifactTo("SampleArtifacts/_/X.txt", "public/chainOfTrust.json.asc")...)
-	command = append(command, copyArtifactTo("SampleArtifacts/_/X.txt", "public/X.txt")...)
-	command = append(command, copyArtifactTo("SampleArtifacts/_/X.txt", "public/Y.txt")...)
+	command = append(command, copyTestdataFileTo("SampleArtifacts/_/X.txt", "public/logs/live.log")...)
+	command = append(command, copyTestdataFileTo("SampleArtifacts/_/X.txt", "public/logs/live_backing.log")...)
+	command = append(command, copyTestdataFileTo("SampleArtifacts/_/X.txt", "public/logs/certified.log")...)
+	command = append(command, copyTestdataFileTo("SampleArtifacts/_/X.txt", "public/chainOfTrust.json.asc")...)
+	command = append(command, copyTestdataFileTo("SampleArtifacts/_/X.txt", "public/X.txt")...)
+	command = append(command, copyTestdataFileTo("SampleArtifacts/_/X.txt", "public/Y.txt")...)
 
 	payload := GenericWorkerPayload{
 		Command:    command,
@@ -509,7 +509,7 @@ func TestPublicDirectoryArtifact(t *testing.T) {
 	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
 
 	command := helloGoodbye()
-	command = append(command, copyArtifactTo("SampleArtifacts/_/X.txt", "public/build/X.txt")...)
+	command = append(command, copyTestdataFileTo("SampleArtifacts/_/X.txt", "public/build/X.txt")...)
 
 	payload := GenericWorkerPayload{
 		Command:    command,
@@ -554,8 +554,8 @@ func TestConflictingFileArtifactsInPayload(t *testing.T) {
 	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
 
 	command := helloGoodbye()
-	command = append(command, copyArtifact("SampleArtifacts/_/X.txt")...)
-	command = append(command, copyArtifact("SampleArtifacts/b/c/d.jpg")...)
+	command = append(command, copyTestdataFile("SampleArtifacts/_/X.txt")...)
+	command = append(command, copyTestdataFile("SampleArtifacts/b/c/d.jpg")...)
 
 	payload := GenericWorkerPayload{
 		Command:    command,
@@ -607,7 +607,7 @@ func TestFileArtifactTwiceInPayload(t *testing.T) {
 	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
 
 	command := helloGoodbye()
-	command = append(command, copyArtifact("SampleArtifacts/_/X.txt")...)
+	command = append(command, copyTestdataFile("SampleArtifacts/_/X.txt")...)
 
 	payload := GenericWorkerPayload{
 		Command:    command,
@@ -659,7 +659,7 @@ func TestArtifactIncludedAsFileAndDirectoryInPayload(t *testing.T) {
 	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
 
 	command := helloGoodbye()
-	command = append(command, copyArtifact("SampleArtifacts/_/X.txt")...)
+	command = append(command, copyTestdataFile("SampleArtifacts/_/X.txt")...)
 
 	payload := GenericWorkerPayload{
 		Command:    command,
@@ -712,8 +712,8 @@ func TestUpload(t *testing.T) {
 	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
 
 	command := helloGoodbye()
-	command = append(command, copyArtifact("SampleArtifacts/_/X.txt")...)
-	command = append(command, copyArtifact("SampleArtifacts/b/c/d.jpg")...)
+	command = append(command, copyTestdataFile("SampleArtifacts/_/X.txt")...)
+	command = append(command, copyTestdataFile("SampleArtifacts/b/c/d.jpg")...)
 
 	payload := GenericWorkerPayload{
 		Command:    command,
@@ -919,7 +919,7 @@ func TestFileArtifactHasNoExpiry(t *testing.T) {
 	defer setup(t, "TestFileArtifactHasNoExpiry")()
 
 	payload := GenericWorkerPayload{
-		Command:    copyArtifact("SampleArtifacts/_/X.txt"),
+		Command:    copyTestdataFile("SampleArtifacts/_/X.txt"),
 		MaxRunTime: 30,
 		Artifacts: []Artifact{
 			{
@@ -956,7 +956,7 @@ func TestDirectoryArtifactHasNoExpiry(t *testing.T) {
 	defer setup(t, "TestDirectoryArtifactHasNoExpiry")()
 
 	payload := GenericWorkerPayload{
-		Command:    copyArtifact("SampleArtifacts/_/X.txt"),
+		Command:    copyTestdataFile("SampleArtifacts/_/X.txt"),
 		MaxRunTime: 30,
 		Artifacts: []Artifact{
 			{

--- a/feature.go
+++ b/feature.go
@@ -15,7 +15,7 @@ type (
 		RequiredScopes() scopes.Required
 		ReservedArtifacts() []string
 		Start() *CommandExecutionError
-		Stop() *CommandExecutionError
+		Stop(err *ExecutionErrors)
 	}
 
 	EnabledFeatures struct {

--- a/garbagecollector.go
+++ b/garbagecollector.go
@@ -65,7 +65,7 @@ func runGarbageCollection(r Resources) error {
 		}
 	}
 	if currentFreeSpace < requiredFreeSpace {
-		return fmt.Errorf("Not able to free up enough disk space - require %v bytes, but only have %v bytes - and nothing left to delete.", requiredFreeSpace, currentFreeSpace)
+		return fmt.Errorf("Not able to free up enough disk space - require %v bytes, but only have %v bytes - and nothing left to delete", requiredFreeSpace, currentFreeSpace)
 	}
 	return nil
 }

--- a/helper_all-unix-style_test.go
+++ b/helper_all-unix-style_test.go
@@ -110,7 +110,7 @@ func sleep(seconds uint) [][]string {
 }
 
 func goRun(goFile string, args ...string) [][]string {
-	copy := copyArtifact(goFile)
+	copy := copyTestdataFile(goFile)
 	run := []string{
 		"go",
 		"run",
@@ -120,11 +120,11 @@ func goRun(goFile string, args ...string) [][]string {
 	return append(copy, runWithArgs)
 }
 
-func copyArtifact(path string) [][]string {
-	return copyArtifactTo(path, path)
+func copyTestdataFile(path string) [][]string {
+	return copyTestdataFileTo(path, path)
 }
 
-func copyArtifactTo(src, dest string) [][]string {
+func copyTestdataFileTo(src, dest string) [][]string {
 	sourcePath := filepath.Join(testdataDir, src)
 	return [][]string{
 		{

--- a/main_test.go
+++ b/main_test.go
@@ -178,7 +178,7 @@ func TestLogFormat(t *testing.T) {
 }
 
 func TestExecutionErrorsText(t *testing.T) {
-	errors := executionErrors{
+	errors := ExecutionErrors{
 		&CommandExecutionError{
 			Cause:      fmt.Errorf("Oh dear oh dear"),
 			Reason:     malformedPayload,

--- a/os_groups.go
+++ b/os_groups.go
@@ -35,7 +35,7 @@ func (feature *OSGroupsFeature) NewTaskFeature(task *TaskRun) TaskFeature {
 	return osGroups
 }
 
-func (feature *OSGroups) ReservedArtifacts() []string {
+func (osGroups *OSGroups) ReservedArtifacts() []string {
 	return []string{}
 }
 
@@ -62,6 +62,5 @@ func (osGroups *OSGroups) Start() (err *CommandExecutionError) {
 	return
 }
 
-func (osGroups *OSGroups) Stop() *CommandExecutionError {
-	return nil
+func (osGroups *OSGroups) Stop(err *ExecutionErrors) {
 }

--- a/plat_all-unix-style.go
+++ b/plat_all-unix-style.go
@@ -137,7 +137,7 @@ func (task *TaskRun) addGroupsToUser(groups []string) error {
 	if len(groups) == 0 {
 		return nil
 	}
-	return fmt.Errorf("Not able to add groups %v to user on platform %v - feature not supported.", groups, runtime.GOOS)
+	return fmt.Errorf("Not able to add groups %v to user on platform %v - feature not supported", groups, runtime.GOOS)
 }
 
 func (task *TaskRun) formatCommand(index int) string {

--- a/rdp_windows.go
+++ b/rdp_windows.go
@@ -71,9 +71,8 @@ func (l *RDPTask) Start() *CommandExecutionError {
 	return l.uploadRDPArtifact()
 }
 
-func (l *RDPTask) Stop() *CommandExecutionError {
+func (l *RDPTask) Stop(err *ExecutionErrors) {
 	time.Sleep(time.Hour * 12)
-	return nil
 }
 
 func (l *RDPTask) createRDPArtifact() {

--- a/supersede.go
+++ b/supersede.go
@@ -43,7 +43,7 @@ type SupersedeTask struct {
 	task *TaskRun
 }
 
-func (feature *SupersedeTask) ReservedArtifacts() []string {
+func (l *SupersedeTask) ReservedArtifacts() []string {
 	return []string{
 		supersededByName,
 	}
@@ -119,6 +119,5 @@ func (l *SupersedeTask) Start() *CommandExecutionError {
 	return nil
 }
 
-func (l *SupersedeTask) Stop() *CommandExecutionError {
-	return nil
+func (l *SupersedeTask) Stop(*ExecutionErrors) {
 }

--- a/taskcluster_proxy.go
+++ b/taskcluster_proxy.go
@@ -37,7 +37,7 @@ type TaskclusterProxyTask struct {
 	taskStatusChangeListener *TaskStatusChangeListener
 }
 
-func (feature *TaskclusterProxyTask) ReservedArtifacts() []string {
+func (l *TaskclusterProxyTask) ReservedArtifacts() []string {
 	return []string{}
 }
 
@@ -101,7 +101,7 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 	return nil
 }
 
-func (l *TaskclusterProxyTask) Stop() *CommandExecutionError {
+func (l *TaskclusterProxyTask) Stop(err *ExecutionErrors) {
 	l.task.StatusManager.DeregisterListener(l.taskStatusChangeListener)
 	errTerminate := l.taskclusterProxy.Terminate()
 	if errTerminate != nil {
@@ -109,5 +109,4 @@ func (l *TaskclusterProxyTask) Stop() *CommandExecutionError {
 		l.task.Warnf("[taskcluster-proxy] Could not terminate taskcluster proxy process: %s", errTerminate)
 		log.Printf("WARNING: could not terminate taskcluster proxy writer: %s", errTerminate)
 	}
-	return nil
 }

--- a/taskstatus.go
+++ b/taskstatus.go
@@ -197,6 +197,12 @@ func (tsm *TaskStatusManager) Abort(cee *CommandExecutionError) error {
 		},
 		claimed,
 		reclaimed,
+		// Since task abortion may take a while, we should continue reclaiming
+		// until we resolve the task. If we didn't do this, but immediately
+		// stopped reclaiming as soon as we had a task abortion, if the task
+		// abortion took too long to complete, the claim might expire before
+		// the task finally gets resolved after the task abortion completes.
+		aborted,
 	)
 }
 

--- a/testdata/move-file.go
+++ b/testdata/move-file.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+func main() {
+	log.SetFlags(0)
+	log.SetPrefix("move-file.go: ")
+	if len(os.Args) != 3 {
+		log.Print("Usage: go run move-file.go [SOURCE_FILE] [TARGET_FILE]")
+		log.Fatalf("Arguments specified: %#v", os.Args[1:])
+	}
+	log.Printf("Moving %v to %v", os.Args[1], os.Args[2])
+	// doesn't happen automatically on Windows
+	err := os.RemoveAll(os.Args[2])
+	if err != nil {
+		log.Printf("Could not remove %v: %s", os.Args[2], err)
+		os.Exit(64)
+	}
+	err = os.Rename(os.Args[1], os.Args[2])
+	if err != nil {
+		log.Printf("Could not rename %v as %v: %s", os.Args[1], os.Args[2], err)
+		os.Exit(65)
+	}
+	log.Print("Moved successfully.")
+}

--- a/testdata/spawn-orphan-process.go
+++ b/testdata/spawn-orphan-process.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+// main spawns a process in a new process group that inherits the stdout/stderr
+// console handles of the parent and runs for approx args[1] seconds
+func main() {
+	log.SetFlags(0)
+	log.SetPrefix(os.Args[0] + ": ")
+	if len(os.Args) < 2 {
+		log.Print("Argument missing - SECONDS must be specified")
+		log.Fatal("Usage: go run spawn-orphan-process.go [SECONDS]")
+	}
+	seconds, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		log.Printf("Invaild argument SECONDS - needs to be an integer, but is '%v'", os.Args[1])
+		log.Fatal("Usage: go run spawn-orphan-process.go [SECONDS]")
+	}
+	// The duration in seconds is approximately equal to the number of pings
+	// minus one (e.g. one ping will return almost immediately, two pings will
+	// return in just over one second, etc).
+	cmd := exec.Command("ping", "127.0.0.1", "-n", strconv.Itoa(seconds+1))
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | syscall.CREATE_UNICODE_ENVIRONMENT,
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Start()
+	if err != nil {
+		log.Fatal("%v", err)
+	}
+}

--- a/update-ssl-creds/main.go
+++ b/update-ssl-creds/main.go
@@ -52,10 +52,10 @@ func main() {
 		if changed {
 			gw := s["generic-worker"].(map[string]interface{})
 			conf := gw["config"].(map[string]interface{})
-			oldDeploymentId := conf["deploymentId"].(string)
-			newDeploymentId := slugid.Nice()
-			log.Printf("New deploymentId for %v: %v => %v", wt, oldDeploymentId, newDeploymentId)
-			conf["deploymentId"] = newDeploymentId
+			oldDeploymentID := conf["deploymentId"].(string)
+			newDeploymentID := slugid.Nice()
+			log.Printf("New deploymentId for %v: %v => %v", wt, oldDeploymentID, newDeploymentID)
+			conf["deploymentId"] = newDeploymentID
 			newBase64EncodedBytes, err := json.Marshal(s)
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
See [bug 1465479](https://bugzilla.mozilla.org/show_bug.cgi?id=1465479) for context.

This was originally a TODO from [#92](https://github.com/taskcluster/generic-worker/pull/92#issuecomment-390289022).

Let's wait for CI to run before reviewing it.

Note I don't currently have a test that reproduces [the regression we saw in production](https://bugzilla.mozilla.org/show_bug.cgi?id=1465112#c3) - I'm not sure what circumstances are required for `taskkill.exe /t` to complete successfully, but `cmd.Wait()` not to immediately return. Presumably it requires creating a subprocess that inherits stdin/stout/stderr handles but starts its own process tree, if such a thing is allowed.

Let me know if you think writing such a test is worthwhile.