### PR TITLE
Bug 1433854 - delete old task user profile directories

### DIFF
--- a/main.go
+++ b/main.go
@@ -1323,7 +1323,7 @@ func removeTaskDirs(parentDir string) {
 	activeTaskUser, _ := AutoLogonCredentials()
 	taskDirsParent, err := os.Open(parentDir)
 	if err != nil {
-		log.Print("WARNING: Could not open " + config.TasksDir + " directory to find old home directories to delete")
+		log.Print("WARNING: Could not open " + parentDir + " directory to find old home directories to delete")
 		log.Printf("%v", err)
 		return
 	}
@@ -1336,7 +1336,7 @@ func removeTaskDirs(parentDir string) {
 	}
 	for _, file := range fi {
 		fileName := file.Name()
-		path := filepath.Join(config.TasksDir, fileName)
+		path := filepath.Join(parentDir, fileName)
 		if file.IsDir() {
 			if strings.HasPrefix(fileName, "task_") && fileName != activeTaskUser {
 				// ignore any error occuring here, not a lot we can do about it...


### PR DESCRIPTION
In the early days, we used to search for and delete task directories under `config.TasksDir` directory, which would e.g. scan `Z:\` and delete directories like:

```
Z:\task_1527860330
```

Since the system user profiles directory is typically elsewhere (e.g. `C:\Users`), sometimes tasks ended up writing to both the task directory (e.g. `Z:\task_1527860330`) and the user profile directory (e.g. `C:\Users\task_1527860330`).

To reduce the occurrences of this, we made sure that `APPDATA` and `LOCALAPPDATA` point inside the task directory, but e.g. `TMP` and `TEMP` are defined in the Default User Profile, may still point inside the system user profiles directory. Note, Microsoft do not support changing the location of the system user profiles directory after Windows has been installed - it should only be configured prior to installation, which is why we can't change it in the worker, since Windows is already installed by the time the generic-worker is running.

Since tasks often end up writing to the user profile directory too, in addition to the task directory, some time ago we updated generic-worker to scan _both_ the tasks directory (e.g. `Z:\`) __and__ the system user profiles directory (e.g. `C:\Users\`) for task folders, and delete them. Unfortunately in the process of parameterising the method that deletes the subfolders (`func removeTaskDirs(parentDir string)`), a couple references to `config.TasksDir` were left over that should have been updated to use the function parameter (`parentDir`).

This PR cleans up that mistake.