### PR TITLE
Bug 1466803 - detect if livelog process terminates before PUT port is active

### DIFF
--- a/livelog.go
+++ b/livelog.go
@@ -87,9 +87,9 @@ func (l *LiveLogTask) Start() *CommandExecutionError {
 }
 
 func (l *LiveLogTask) updateTaskLogWriter(liveLogWriter io.Writer) *CommandExecutionError {
-	// store current writer so it can be reinstated later when stopping livelog
 	l.task.logMux.Lock()
 	defer l.task.logMux.Unlock()
+	// store current writer so it can be reinstated later when stopping livelog
 	l.backingLogFile = l.task.logWriter.(*os.File)
 	// write logs written so far to livelog
 	// first rewind to beginning of backing log...

--- a/livelog/livelog_test.go
+++ b/livelog/livelog_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httputil"
 	"runtime"
 	"testing"
+	"time"
 )
 
 func TestLiveLog(t *testing.T) {
@@ -43,7 +44,10 @@ func TestLiveLog(t *testing.T) {
 	// writes data to it, which probably should be fixed in the livelog
 	// codebase. Ideally it would serve both ports on initialisation, not
 	// requiring data to be PUT first.
-	waitForPortToBeActive(ll.GETPort)
+	err = waitForPortToBeActive(ll.GETPort, time.Minute*1)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
 	resp, err := http.Get(ll.GetURL)
 	if err != nil {
 		t.Fatalf("Could not GET livelog from URL %s:\n%s", ll.GetURL, err)


### PR DESCRIPTION
Previously, we started the livelog process, and then polled the PUT port for up to one minute to wait for it to be active.

If the livelog process returns while we are waiting for the port to be active, we know something has gone wrong, and can immediately return an error, rather than waiting the full minute to return an error.

This change also tracks the command output from the livelog command, so that if the process does fail, we have the output from the command logged in the task's backing log which gets uploaded when the task is resolved.