### PR TITLE
Bug 1469402 - Add a onExitStatus section to the payload

### DIFF
--- a/all-unix-style.yml
+++ b/all-unix-style.yml
@@ -150,6 +150,22 @@ properties:
           [the github project](https://github.com/taskcluster/taskcluster-proxy) for more information.
 
           Since: generic-worker 10.6.0
+  onExitStatus:
+    title: Exit status handling
+    description: By default generic-worker will fail a task with a non-zero exit status
+      without retrying.  This payload property allows a task owner to define certain
+      exit statuses that will be marked as a retriable exception.
+    type: object
+    additionalProperties: false
+    properties:
+      retry:
+        title: Retriable exit statuses
+        description: If the task exists with a retriable exit status, the task will
+          be marked as an exception and a new run created.
+        type: array
+        items:
+          title: Exit statuses
+          type: integer
   mounts:
     type: array
     description: |-

--- a/all-unix-style.yml
+++ b/all-unix-style.yml
@@ -151,20 +151,23 @@ properties:
 
           Since: generic-worker 10.6.0
   onExitStatus:
-    title: Exit status handling
-    description: By default generic-worker will fail a task with a non-zero exit status
+    title: Exit code handling
+    description: By default generic-worker will fail a task with a non-zero exit code
       without retrying.  This payload property allows a task owner to define certain
-      exit statuses that will be marked as a retriable exception.
+      exit codes that are handled differently.
     type: object
     additionalProperties: false
     properties:
       retry:
-        title: Retriable exit statuses
-        description: If the task exists with a retriable exit status, the task will
-          be marked as an exception and a new run created.
+        title: Intermittent task exit codes
+        description: If the task exists with a retriable exit code, the task will
+          be marked as an exception with a reason of intermitten-task.
+          This may cause the queue to rerun the task.
+
+          See [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.
         type: array
         items:
-          title: Exit statuses
+          title: Exit codes
           type: integer
   mounts:
     type: array

--- a/generated_all-unix-style.go
+++ b/generated_all-unix-style.go
@@ -78,10 +78,11 @@ type (
 		TaskID string `json:"taskId"`
 	}
 
-	// By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
-	ExitStatusHandling struct {
+	// By default generic-worker will fail a task with a non-zero exit code without retrying.  This payload property allows a task owner to define certain exit codes that are handled differently.
+	ExitCodeHandling struct {
 
-		// If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.
+		// If the task exists with a retriable exit code, the task will be marked as an exception with a reason of intermitten-task. This may cause the queue to rerun the task.
+		// See [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.
 		Retry []int64 `json:"retry,omitempty"`
 	}
 
@@ -165,8 +166,8 @@ type (
 		// Since: generic-worker 5.4.0
 		Mounts []json.RawMessage `json:"mounts,omitempty"`
 
-		// By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
-		OnExitStatus ExitStatusHandling `json:"onExitStatus,omitempty"`
+		// By default generic-worker will fail a task with a non-zero exit code without retrying.  This payload property allows a task owner to define certain exit codes that are handled differently.
+		OnExitStatus ExitCodeHandling `json:"onExitStatus,omitempty"`
 
 		// A list of OS Groups that the task user should be a member of. Requires
 		// scope `generic-worker:os-group:<os-group>` for each group listed.
@@ -549,19 +550,19 @@ func taskPayloadSchema() string {
     },
     "onExitStatus": {
       "additionalProperties": false,
-      "description": "By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.",
+      "description": "By default generic-worker will fail a task with a non-zero exit code without retrying.  This payload property allows a task owner to define certain exit codes that are handled differently.",
       "properties": {
         "retry": {
-          "description": "If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.",
+          "description": "If the task exists with a retriable exit code, the task will be marked as an exception with a reason of intermitten-task. This may cause the queue to rerun the task.\nSee [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.",
           "items": {
-            "title": "Exit statuses",
+            "title": "Exit codes",
             "type": "integer"
           },
-          "title": "Retriable exit statuses",
+          "title": "Intermittent task exit codes",
           "type": "array"
         }
       },
-      "title": "Exit status handling",
+      "title": "Exit code handling",
       "type": "object"
     },
     "osGroups": {

--- a/generated_all-unix-style.go
+++ b/generated_all-unix-style.go
@@ -78,6 +78,13 @@ type (
 		TaskID string `json:"taskId"`
 	}
 
+	// By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+	ExitStatusHandling struct {
+
+		// If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.
+		Retry []int64 `json:"retry,omitempty"`
+	}
+
 	// Feature flags enable additional functionality.
 	//
 	// Since: generic-worker 5.3.0
@@ -157,6 +164,9 @@ type (
 		//
 		// Since: generic-worker 5.4.0
 		Mounts []json.RawMessage `json:"mounts,omitempty"`
+
+		// By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+		OnExitStatus ExitStatusHandling `json:"onExitStatus,omitempty"`
 
 		// A list of OS Groups that the task user should be a member of. Requires
 		// scope `generic-worker:os-group:<os-group>` for each group listed.
@@ -536,6 +546,23 @@ func taskPayloadSchema() string {
         "title": "Mount"
       },
       "type": "array"
+    },
+    "onExitStatus": {
+      "additionalProperties": false,
+      "description": "By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.",
+      "properties": {
+        "retry": {
+          "description": "If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.",
+          "items": {
+            "title": "Exit statuses",
+            "type": "integer"
+          },
+          "title": "Retriable exit statuses",
+          "type": "array"
+        }
+      },
+      "title": "Exit status handling",
+      "type": "object"
     },
     "osGroups": {
       "description": "A list of OS Groups that the task user should be a member of. Requires\nscope ` + "`" + `generic-worker:os-group:\u003cos-group\u003e` + "`" + ` for each group listed.\n\nSince: generic-worker 6.0.0",

--- a/generated_windows.go
+++ b/generated_windows.go
@@ -76,6 +76,13 @@ type (
 		TaskID string `json:"taskId"`
 	}
 
+	// By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+	ExitStatusHandling struct {
+
+		// If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.
+		Retry []int64 `json:"retry,omitempty"`
+	}
+
 	// Feature flags enable additional functionality.
 	//
 	// Since: generic-worker 5.3.0
@@ -162,6 +169,9 @@ type (
 		//
 		// Since: generic-worker 5.4.0
 		Mounts []json.RawMessage `json:"mounts,omitempty"`
+
+		// By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+		OnExitStatus ExitStatusHandling `json:"onExitStatus,omitempty"`
 
 		// A list of OS Groups that the task user should be a member of. Requires
 		// scope `generic-worker:os-group:<os-group>` for each group listed.
@@ -565,6 +575,23 @@ func taskPayloadSchema() string {
         "title": "Mount"
       },
       "type": "array"
+    },
+    "onExitStatus": {
+      "additionalProperties": false,
+      "description": "By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.",
+      "properties": {
+        "retry": {
+          "description": "If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.",
+          "items": {
+            "title": "Exit statuses",
+            "type": "integer"
+          },
+          "title": "Retriable exit statuses",
+          "type": "array"
+        }
+      },
+      "title": "Exit status handling",
+      "type": "object"
     },
     "osGroups": {
       "description": "A list of OS Groups that the task user should be a member of. Requires\nscope ` + "`" + `generic-worker:os-group:\u003cos-group\u003e` + "`" + ` for each group listed.\n\nSince: generic-worker 6.0.0",

--- a/generated_windows.go
+++ b/generated_windows.go
@@ -76,10 +76,11 @@ type (
 		TaskID string `json:"taskId"`
 	}
 
-	// By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
-	ExitStatusHandling struct {
+	// By default generic-worker will fail a task with a non-zero exit code without retrying.  This payload property allows a task owner to define certain exit codes that are handled differently.
+	ExitCodeHandling struct {
 
-		// If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.
+		// If the task exists with a retriable exit code, the task will be marked as an exception with a reason of intermitten-task. This may cause the queue to rerun the task.
+		// See [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.
 		Retry []int64 `json:"retry,omitempty"`
 	}
 
@@ -170,8 +171,8 @@ type (
 		// Since: generic-worker 5.4.0
 		Mounts []json.RawMessage `json:"mounts,omitempty"`
 
-		// By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
-		OnExitStatus ExitStatusHandling `json:"onExitStatus,omitempty"`
+		// By default generic-worker will fail a task with a non-zero exit code without retrying.  This payload property allows a task owner to define certain exit codes that are handled differently.
+		OnExitStatus ExitCodeHandling `json:"onExitStatus,omitempty"`
 
 		// A list of OS Groups that the task user should be a member of. Requires
 		// scope `generic-worker:os-group:<os-group>` for each group listed.
@@ -578,19 +579,19 @@ func taskPayloadSchema() string {
     },
     "onExitStatus": {
       "additionalProperties": false,
-      "description": "By default generic-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.",
+      "description": "By default generic-worker will fail a task with a non-zero exit code without retrying.  This payload property allows a task owner to define certain exit codes that are handled differently.",
       "properties": {
         "retry": {
-          "description": "If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.",
+          "description": "If the task exists with a retriable exit code, the task will be marked as an exception with a reason of intermitten-task. This may cause the queue to rerun the task.\nSee [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.",
           "items": {
-            "title": "Exit statuses",
+            "title": "Exit codes",
             "type": "integer"
           },
-          "title": "Retriable exit statuses",
+          "title": "Intermittent task exit codes",
           "type": "array"
         }
       },
-      "title": "Exit status handling",
+      "title": "Exit code handling",
       "type": "object"
     },
     "osGroups": {

--- a/helper_all-unix-style_test.go
+++ b/helper_all-unix-style_test.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"fmt"
+
 	"path/filepath"
 	"strconv"
 )
@@ -46,10 +48,12 @@ func checkSHASums() [][]string {
 	}
 }
 
-func failCommand() [][]string {
+func returnExitCode(exitCode uint) [][]string {
 	return [][]string{
 		{
-			"false",
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf("exit %d", exitCode),
 		},
 	}
 }

--- a/helper_windows_test.go
+++ b/helper_windows_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -27,9 +28,9 @@ func checkSHASums() []string {
 	}
 }
 
-func failCommand() []string {
+func returnExitCode(exitCode uint) []string {
 	return []string{
-		"exit 1",
+		fmt.Sprintf("exit %d", exitCode),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -946,7 +946,7 @@ func (err *CommandExecutionError) Error() string {
 	return fmt.Sprintf("%v", err.Cause)
 }
 
-func (task *TaskRun) RetryExitCode(c int64) bool {
+func (task *TaskRun) IsIntermittentExitCode(c int64) bool {
 	for _, code := range task.Payload.OnExitStatus.Retry {
 		if c == code {
 			return true
@@ -970,9 +970,9 @@ func (task *TaskRun) ExecuteCommand(index int) *CommandExecutionError {
 
 	switch {
 	case result.Failed():
-		if task.RetryExitCode(int64(result.ExitCode())) {
+		if task.IsIntermittentExitCode(int64(result.ExitCode())) {
 			return &CommandExecutionError{
-				Cause:      fmt.Errorf("Intermittent task will be rerun. Exit code was in onExitStatusList"),
+				Cause:      fmt.Errorf("Task appears to have failed intermittently - exit code %v found in task payload.onExitStatus list", result.ExitCode()),
 				Reason:     intermittentTask,
 				TaskStatus: errored,
 			}

--- a/main.go
+++ b/main.go
@@ -946,6 +946,15 @@ func (err *CommandExecutionError) Error() string {
 	return fmt.Sprintf("%v", err.Cause)
 }
 
+func (task *TaskRun) RetryExitCode(c int64) bool {
+	for _, code := range task.Payload.OnExitStatus.Retry {
+		if c == code {
+			return true
+		}
+	}
+	return false
+}
+
 func (task *TaskRun) ExecuteCommand(index int) *CommandExecutionError {
 	task.Infof("Executing command %v: %v", index, task.formatCommand(index))
 	log.Print("Executing command " + strconv.Itoa(index) + ": " + task.Commands[index].String())
@@ -961,9 +970,17 @@ func (task *TaskRun) ExecuteCommand(index int) *CommandExecutionError {
 
 	switch {
 	case result.Failed():
-		return &CommandExecutionError{
-			Cause:      result.FailureCause(),
-			TaskStatus: failed,
+		if task.RetryExitCode(int64(result.ExitCode())) {
+			return &CommandExecutionError{
+				Cause:      fmt.Errorf("Intermittent task will be rerun. Exit code was in onExitStatusList"),
+				Reason:     intermittentTask,
+				TaskStatus: errored,
+			}
+		} else {
+			return &CommandExecutionError{
+				Cause:      result.FailureCause(),
+				TaskStatus: failed,
+			}
 		}
 	case result.Crashed():
 		panic(result.CrashCause())

--- a/main_test.go
+++ b/main_test.go
@@ -27,11 +27,11 @@ func TestFailureResolvesAsFailure(t *testing.T) {
 
 // Exit codes specified in OnExitCode should resolve as itermittent
 func TestFailureRetryCode(t *testing.T) {
-	defer setup(t, "TestFailureResolvesAsFailure")()
+	defer setup(t, "TestFailureRetryCode")()
 	payload := GenericWorkerPayload{
 		Command:    returnExitCode(123),
 		MaxRunTime: 10,
-		OnExitStatus: ExitStatusHandling{
+		OnExitStatus: ExitCodeHandling{
 			Retry: []int64{123},
 		},
 	}
@@ -44,11 +44,11 @@ func TestFailureRetryCode(t *testing.T) {
 
 // Exit codes _not_ specified in OnExitCode should resolve normally
 func TestFailureRetryCodeNormal(t *testing.T) {
-	defer setup(t, "TestFailureResolvesAsFailure")()
+	defer setup(t, "TestFailureRetryCodeNormal")()
 	payload := GenericWorkerPayload{
 		Command:    returnExitCode(456),
 		MaxRunTime: 10,
-		OnExitStatus: ExitStatusHandling{
+		OnExitStatus: ExitCodeHandling{
 			Retry: []int64{123},
 		},
 	}
@@ -61,11 +61,11 @@ func TestFailureRetryCodeNormal(t *testing.T) {
 
 // Exit codes should not override success
 func TestFailureRetryCodeSuccess(t *testing.T) {
-	defer setup(t, "TestFailureResolvesAsFailure")()
+	defer setup(t, "TestFailureRetryCodeSuccess")()
 	payload := GenericWorkerPayload{
 		Command:    returnExitCode(0),
 		MaxRunTime: 10,
-		OnExitStatus: ExitStatusHandling{
+		OnExitStatus: ExitCodeHandling{
 			Retry: []int64{780},
 		},
 	}
@@ -74,6 +74,57 @@ func TestFailureRetryCodeSuccess(t *testing.T) {
 	fmt.Print(td)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
+}
+
+// Exit codes as a list
+func TestFailureRetryCodeList(t *testing.T) {
+	defer setup(t, "TestFailureRetryCodeList")()
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(10),
+		MaxRunTime: 10,
+		OnExitStatus: ExitCodeHandling{
+			Retry: []int64{780, 10, 2},
+		},
+	}
+	td := testTask(t)
+
+	fmt.Print(td)
+
+	_ = submitAndAssert(t, td, payload, "exception", "intermittent-task")
+}
+
+// Exit codes with empty list are fine
+func TestFailureRetryCodeEmpty(t *testing.T) {
+	defer setup(t, "TestFailureRetryCodeEmpty")()
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(0),
+		MaxRunTime: 10,
+		OnExitStatus: ExitCodeHandling{
+			Retry: []int64{},
+		},
+	}
+	td := testTask(t)
+
+	fmt.Print(td)
+
+	_ = submitAndAssert(t, td, payload, "completed", "completed")
+}
+
+// Exit codes with empty list are fine (failure)
+func TestFailureRetryCodeEmptyFail(t *testing.T) {
+	defer setup(t, "TestFailureRetryCodeEmptyFail")()
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(1),
+		MaxRunTime: 10,
+		OnExitStatus: ExitCodeHandling{
+			Retry: []int64{},
+		},
+	}
+	td := testTask(t)
+
+	fmt.Print(td)
+
+	_ = submitAndAssert(t, td, payload, "failed", "failed")
 }
 
 func TestAbortAfterMaxRunTime(t *testing.T) {

--- a/windows.yml
+++ b/windows.yml
@@ -186,6 +186,22 @@ properties:
 
       Since: generic-worker 10.2.2
     format: uri
+  onExitStatus:
+    title: Exit status handling
+    description: By default generic-worker will fail a task with a non-zero exit status
+      without retrying.  This payload property allows a task owner to define certain
+      exit statuses that will be marked as a retriable exception.
+    type: object
+    additionalProperties: false
+    properties:
+      retry:
+        title: Retriable exit statuses
+        description: If the task exists with a retriable exit status, the task will
+          be marked as an exception and a new run created.
+        type: array
+        items:
+          title: Exit statuses
+          type: integer
   rdpInfo:
     type: string
     title: RDP Info

--- a/windows.yml
+++ b/windows.yml
@@ -187,20 +187,23 @@ properties:
       Since: generic-worker 10.2.2
     format: uri
   onExitStatus:
-    title: Exit status handling
-    description: By default generic-worker will fail a task with a non-zero exit status
+    title: Exit code handling
+    description: By default generic-worker will fail a task with a non-zero exit code
       without retrying.  This payload property allows a task owner to define certain
-      exit statuses that will be marked as a retriable exception.
+      exit codes that are handled differently.
     type: object
     additionalProperties: false
     properties:
       retry:
-        title: Retriable exit statuses
-        description: If the task exists with a retriable exit status, the task will
-          be marked as an exception and a new run created.
+        title: Intermittent task exit codes
+        description: If the task exists with a retriable exit code, the task will
+          be marked as an exception with a reason of intermitten-task.
+          This may cause the queue to rerun the task.
+
+          See [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.
         type: array
         items:
-          title: Exit statuses
+          title: Exit codes
           type: integer
   rdpInfo:
     type: string


### PR DESCRIPTION
This is an attempt at adding `onExitStatus` like we have in docker-worker. If what I've done here mostly makes sense maybe you can give some pointers on testing that I should do and I'll try to do that tomorrow!

Note 1: This appears to work from running the worker locally and submitting test jobs.
Note 2: I'm not sure why the tests are failing? Something to do with `git status` on the mac builder at least. 