### PR TITLE
Bug 1475689 - don't wait for commands to complete with (*os/exec.Cmd).Wait()

### DIFF
--- a/process/process_all-unix-style.go
+++ b/process/process_all-unix-style.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"os/exec"
-	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -16,12 +15,19 @@ import (
 type Command struct {
 	mutex sync.RWMutex
 	*exec.Cmd
+	// abort channel is closed when Kill() is called so that Execute() can
+	// return even if cmd.Wait() is blocked. This is useful since cmd.Wait()
+	// sometimes does not return promptly.
+	abort chan struct{}
 }
 
 type Result struct {
 	SystemError error
 	ExitError   *exec.ExitError
 	Duration    time.Duration
+	Aborted     bool
+	KernelTime  time.Duration
+	UserTime    time.Duration
 }
 
 func (r *Result) Succeeded() bool {
@@ -29,7 +35,7 @@ func (r *Result) Succeeded() bool {
 }
 
 func (r *Result) Failed() bool {
-	return r.SystemError == nil && r.ExitError != nil
+	return (r.SystemError == nil && r.ExitError != nil) || r.Aborted
 }
 
 func (r *Result) CrashCause() error {
@@ -41,7 +47,7 @@ func (r *Result) FailureCause() *exec.ExitError {
 }
 
 func (r *Result) Crashed() bool {
-	return r.SystemError != nil
+	return r.SystemError != nil && !r.Aborted
 }
 
 func NewCommand(commandLine []string, workingDirectory string, env []string) (*Command, error) {
@@ -51,7 +57,8 @@ func NewCommand(commandLine []string, workingDirectory string, env []string) (*C
 	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return &Command{
-		Cmd: cmd,
+		Cmd:   cmd,
+		abort: make(chan struct{}),
 	}, nil
 }
 
@@ -59,7 +66,11 @@ func NewCommand(commandLine []string, workingDirectory string, env []string) (*C
 //  -1 if the process has not exited
 //  -2 if the process crashed
 //  -3 it could not be established what happened
+//  -4 if process was aborted
 func (r *Result) ExitCode() int {
+	if r.Aborted {
+		return -4
+	}
 	if r.SystemError != nil {
 		return -2
 	}
@@ -82,17 +93,30 @@ func (c *Command) Execute() (r *Result) {
 		r.SystemError = err
 		return
 	}
-	err = c.Wait()
+	exitErr := make(chan error)
+	// wait for command to complete in separate go routine, so we handle abortion in parallel to command termination
+	go func() {
+		err := c.Wait()
+		exitErr <- err
+	}()
+	select {
+	case err = <-exitErr:
+		r.UserTime = c.ProcessState.UserTime()
+		r.KernelTime = c.ProcessState.SystemTime()
+		if err != nil {
+			if exiterr, ok := err.(*exec.ExitError); ok {
+				r.ExitError = exiterr
+			} else {
+				r.SystemError = err
+			}
+		}
+	case <-c.abort:
+		r.SystemError = fmt.Errorf("Process aborted")
+		r.Aborted = true
+	}
 	finished := time.Now()
 	// Round(0) forces wall time calculation instead of monotonic time in case machine slept etc
 	r.Duration = finished.Round(0).Sub(started)
-	if err != nil {
-		if exiterr, ok := err.(*exec.ExitError); ok {
-			r.ExitError = exiterr
-		} else {
-			r.SystemError = err
-		}
-	}
 	return
 }
 
@@ -101,7 +125,32 @@ func (c *Command) String() string {
 }
 
 func (r *Result) String() string {
-	return "Exit Code: " + strconv.Itoa(r.ExitCode())
+	if r.Aborted {
+		return fmt.Sprintf("Command ABORTED after %v", r.Duration)
+	}
+	return fmt.Sprintf(""+
+		"   Exit Code: %v\n"+
+		"   User Time: %v\n"+
+		" Kernel Time: %v\n"+
+		"   Wall Time: %v\n"+
+		"      Result: %v",
+		r.ExitCode(),
+		r.UserTime,
+		r.KernelTime,
+		r.Duration,
+		r.Verdict(),
+	)
+}
+
+func (r *Result) Verdict() string {
+	switch {
+	case r.Aborted:
+		return "ABORTED"
+	case r.ExitError == nil:
+		return "SUCCEEDED"
+	default:
+		return "FAILED"
+	}
 }
 
 func (c *Command) DirectOutput(writer io.Writer) {
@@ -116,8 +165,9 @@ func (c *Command) Kill() ([]byte, error) {
 		// If process hasn't been started yet, nothing to kill
 		return []byte{}, nil
 	}
-	log.Printf("Killing process with ID %v... (%p)", c.Process.Pid, c)
-	defer log.Printf("Process with ID %v killed.", c.Process.Pid)
+	close(c.abort)
+	log.Printf("Killing process tree with parent PID %v... (%p)", c.Process.Pid, c)
+	defer log.Printf("Process tree with parent PID %v killed.", c.Process.Pid)
 	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
 	return []byte{}, syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
 }


### PR DESCRIPTION
See [bug 1475689](https://bugzil.la/1475689) for context.

Calling https://golang.org/pkg/os/exec/#Cmd.Wait can mean that you wait forever if a process gets stuck and can't be killed when a task is aborted.

Instead, signal task abortion via the closing of a go channel so that task abortion can be handled in parallel to process termination. This was already implemented on Windows, this applies a similar fix for all other platforms.