### PR TITLE
Bug 1480412 - allow empty osGroups list on non-Windows platforms

### DIFF
--- a/all-unix-style.yml
+++ b/all-unix-style.yml
@@ -159,6 +159,18 @@ properties:
     items:
       title: Mount
       "$ref": "#/definitions/mount"
+  osGroups:
+    type: array
+    title: OS Groups
+    description: |-
+      A list of OS Groups that the task user should be a member of. Not yet implemented on
+      non-Windows platforms, therefore this optional property may only be an empty array if
+      provided.
+
+      Since: generic-worker 6.0.0
+    items:
+      type: string
+    maxItems: 0
   supersederUrl:
     type: string
     title: Superseder URL

--- a/generated_all-unix-style.go
+++ b/generated_all-unix-style.go
@@ -181,6 +181,13 @@ type (
 		// based on exit code of task commands.
 		OnExitStatus ExitCodeHandling `json:"onExitStatus,omitempty"`
 
+		// A list of OS Groups that the task user should be a member of. Not yet implemented on
+		// non-Windows platforms, therefore this optional property may only be an empty array if
+		// provided.
+		//
+		// Since: generic-worker 6.0.0
+		OSGroups []string `json:"osGroups,omitempty"`
+
 		// URL of a service that can indicate tasks superseding this one; the current `taskId`
 		// will be appended as a query argument `taskId`. The service should return an object with
 		// a `supersedes` key containing a list of `taskId`s, including the supplied `taskId`. The
@@ -571,6 +578,15 @@ func taskPayloadSchema() string {
       },
       "title": "Exit code handling",
       "type": "object"
+    },
+    "osGroups": {
+      "description": "A list of OS Groups that the task user should be a member of. Not yet implemented on\nnon-Windows platforms, therefore this optional property may only be an empty array if\nprovided.\n\nSince: generic-worker 6.0.0",
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 0,
+      "title": "OS Groups",
+      "type": "array"
     },
     "supersederUrl": {
       "description": "URL of a service that can indicate tasks superseding this one; the current ` + "`" + `taskId` + "`" + `\nwill be appended as a query argument ` + "`" + `taskId` + "`" + `. The service should return an object with\na ` + "`" + `supersedes` + "`" + ` key containing a list of ` + "`" + `taskId` + "`" + `s, including the supplied ` + "`" + `taskId` + "`" + `. The\ntasks should be ordered such that each task supersedes all tasks appearing later in the\nlist.\n\nSee [superseding](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/superseding) for more detail.\n\nSince: generic-worker 10.2.2",

--- a/main.go
+++ b/main.go
@@ -356,6 +356,7 @@ func initialiseFeatures() (err error) {
 	Features = []Feature{
 		&LiveLogFeature{},
 		&TaskclusterProxyFeature{},
+		&OSGroupsFeature{},
 		&MountsFeature{},
 		&SupersedeFeature{},
 	}

--- a/os_groups.go
+++ b/os_groups.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"github.com/taskcluster/taskcluster-base-go/scopes"
+)
+
+// one instance overall - represents feature
+type OSGroupsFeature struct {
+}
+
+// one instance per task
+type OSGroups struct {
+	Task *TaskRun
+	// keep track of which groups we successfully update
+	AddedGroups []string
+}
+
+func (feature *OSGroupsFeature) Name() string {
+	return "OS Groups"
+}
+
+func (feature *OSGroupsFeature) Initialise() error {
+	return nil
+}
+
+func (feature *OSGroupsFeature) PersistState() error {
+	return nil
+}
+
+func (feature *OSGroupsFeature) IsEnabled(task *TaskRun) bool {
+	// always enabled, since scopes protect usage at a group level
+	return true
+}
+
+func (feature *OSGroupsFeature) NewTaskFeature(task *TaskRun) TaskFeature {
+	osGroups := &OSGroups{
+		Task: task,
+	}
+	return osGroups
+}
+
+func (osGroups *OSGroups) ReservedArtifacts() []string {
+	return []string{}
+}
+
+func (osGroups *OSGroups) RequiredScopes() scopes.Required {
+	requiredScopes := make([]string, len(osGroups.Task.Payload.OSGroups), len(osGroups.Task.Payload.OSGroups))
+	for i, osGroup := range osGroups.Task.Payload.OSGroups {
+		requiredScopes[i] = "generic-worker:os-group:" + config.ProvisionerID + "/" + config.WorkerType + "/" + osGroup
+	}
+	return scopes.Required{requiredScopes}
+}

--- a/os_groups_all-unix-style.go
+++ b/os_groups_all-unix-style.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func (osGroups *OSGroups) Start() *CommandExecutionError {
+	if len(osGroups.Task.Payload.OSGroups) > 0 {
+		return MalformedPayloadError(fmt.Errorf("osGroups feature is not supported on platform %v - please modify task definition and try again", runtime.GOOS))
+	}
+	return nil
+}
+
+func (osGroups *OSGroups) Stop(err *ExecutionErrors) {
+}

--- a/os_groups_all-unix-style_test.go
+++ b/os_groups_all-unix-style_test.go
@@ -1,0 +1,44 @@
+// +build !windows
+
+package main
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEmptyOSGroups(t *testing.T) {
+	defer setup(t)()
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		OSGroups:   []string{},
+	}
+	td := testTask(t)
+
+	_ = submitAndAssert(t, td, payload, "completed", "completed")
+}
+
+func TestNonEmptyOSGroups(t *testing.T) {
+	defer setup(t)()
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		OSGroups:   []string{"abc"},
+	}
+	td := testTask(t)
+
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+
+	// check log mentions issue
+	bytes, err := ioutil.ReadFile(filepath.Join(taskContext.TaskDir, logPath))
+	if err != nil {
+		t.Fatalf("Error when trying to read log file: %v", err)
+	}
+	logtext := string(bytes)
+	if !strings.Contains(logtext, "- osGroups: Array must have at most 0 items") {
+		t.Fatalf("Was expecting log file to contain '- osGroups: Array must have at most 0 items' but it doesn't")
+	}
+}

--- a/os_groups_windows.go
+++ b/os_groups_windows.go
@@ -2,56 +2,7 @@ package main
 
 import (
 	"fmt"
-
-	"github.com/taskcluster/taskcluster-base-go/scopes"
 )
-
-// one instance overall - represents feature
-type OSGroupsFeature struct {
-}
-
-// one instance per task
-type OSGroups struct {
-	Task *TaskRun
-	// keep track of which groups we successfully update
-	AddedGroups []string
-}
-
-func (feature *OSGroupsFeature) Name() string {
-	return "OS Groups"
-}
-
-func (feature *OSGroupsFeature) Initialise() error {
-	return nil
-}
-
-func (feature *OSGroupsFeature) PersistState() error {
-	return nil
-}
-
-func (feature *OSGroupsFeature) IsEnabled(task *TaskRun) bool {
-	// always enabled, since scopes protect usage at a group level
-	return true
-}
-
-func (feature *OSGroupsFeature) NewTaskFeature(task *TaskRun) TaskFeature {
-	osGroups := &OSGroups{
-		Task: task,
-	}
-	return osGroups
-}
-
-func (osGroups *OSGroups) ReservedArtifacts() []string {
-	return []string{}
-}
-
-func (osGroups *OSGroups) RequiredScopes() scopes.Required {
-	requiredScopes := make([]string, len(osGroups.Task.Payload.OSGroups), len(osGroups.Task.Payload.OSGroups))
-	for i, osGroup := range osGroups.Task.Payload.OSGroups {
-		requiredScopes[i] = "generic-worker:os-group:" + config.ProvisionerID + "/" + config.WorkerType + "/" + osGroup
-	}
-	return scopes.Required{requiredScopes}
-}
 
 func (osGroups *OSGroups) Start() *CommandExecutionError {
 	groups := osGroups.Task.Payload.OSGroups

--- a/os_groups_windows_test.go
+++ b/os_groups_windows_test.go
@@ -12,7 +12,7 @@ func TestMissingScopesOSGroups(t *testing.T) {
 	defer setup(t)()
 	payload := GenericWorkerPayload{
 		Command:    helloGoodbye(),
-		MaxRunTime: 1,
+		MaxRunTime: 30,
 		OSGroups:   []string{"abc", "def"},
 	}
 	td := testTask(t)

--- a/plat_windows.go
+++ b/plat_windows.go
@@ -90,7 +90,6 @@ type TaskContext struct {
 func platformFeatures() []Feature {
 	return []Feature{
 		&RDPFeature{},
-		&OSGroupsFeature{},
 		&RunAsAdministratorFeature{}, // depends on (must appear later in list than) OSGroups feature
 	}
 }


### PR DESCRIPTION
See [bug 1480412](https://bugzil.la/1480412) for more details.

Since `osGroups` feature isn't supported on non-Windows platforms currently, in the most recent release (10.11.2) I had moved the `osGroups` code into the Windows codebase (`*_windows.go` files) from the cross platform go files. I hadn't realised that the gecko task generation code was creating non-Windows tasks specifying an empty `osGroups` list (`[]`). Rather than fix the task generation in all gecko trees/branches (and any other projects that might be doing the same) not to allow `osGroups` for platforms where this feature is not implemented, this PR ensures that the only acceptable value for `osGroups` on a non-Windows platform is the empty list (i.e. "no groups").

The reason it isn't implemented on those other platforms is that the tasks run as the same user as the worker process. Since the user cannot grant itself more privileges than it already has, this feature only makes sense on platforms where the task runs as a different user to the worker process, which currently is only Windows.

Specifying a non-empty list will result in a malformed-payload exception.

This PR is mostly the undoing of the previous refactor, i.e. moving the code from windows-only go files (`*_windows_*.go` files) back to the cross platform (`*.go`) files and a couple of tests to ensure it works.