### PR TITLE
Support GCE as an environment

### DIFF
--- a/aws_helper_test.go
+++ b/aws_helper_test.go
@@ -117,7 +117,7 @@ func (m *MockAWSProvisionedEnvironment) Setup(t *testing.T) func() {
 		t.Log("HTTP server for mock Provisioner and EC2 metadata endpoints stopped")
 	}()
 	var err error
-	config, err = loadConfig(filepath.Join(testdataDir, t.Name(), "generic-worker.config"), true)
+	config, err = loadConfig(filepath.Join(testdataDir, t.Name(), "generic-worker.config"), true, false)
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -13,7 +13,7 @@ import (
 func TestMissingIPConfig(t *testing.T) {
 	file := filepath.Join("testdata", "config", "noip.json")
 	const setting = "publicIP"
-	config, err := loadConfig(file, false)
+	config, err := loadConfig(file, false, false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -35,7 +35,7 @@ func TestValidConfig(t *testing.T) {
 	file := filepath.Join("testdata", "config", "valid.json")
 	const ipaddr = "2.1.2.1"
 	const workerType = "some-worker-type"
-	config, err := loadConfig(file, false)
+	config, err := loadConfig(file, false, false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -53,7 +53,7 @@ func TestValidConfig(t *testing.T) {
 
 func TestInvalidIPConfig(t *testing.T) {
 	file := filepath.Join("testdata", "config", "invalid-ip.json")
-	_, err := loadConfig(file, false)
+	_, err := loadConfig(file, false, false)
 	if err == nil {
 		t.Fatal("Was expecting to get an error back due to an invalid IP address, but didn't get one!")
 	}
@@ -67,7 +67,7 @@ func TestInvalidIPConfig(t *testing.T) {
 
 func TestInvalidJsonConfig(t *testing.T) {
 	file := filepath.Join("testdata", "config", "invalid-json.json")
-	_, err := loadConfig(file, false)
+	_, err := loadConfig(file, false, false)
 	if err == nil {
 		t.Fatal("Was expecting to get an error back due to an invalid JSON config, but didn't get one!")
 	}
@@ -81,7 +81,7 @@ func TestInvalidJsonConfig(t *testing.T) {
 
 func TestMissingConfigFile(t *testing.T) {
 	file := filepath.Join("testdata", "config", "non-existent-json.json")
-	config, err := loadConfig(file, false)
+	config, err := loadConfig(file, false, false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -99,7 +99,7 @@ func TestMissingConfigFile(t *testing.T) {
 
 func TestWorkerTypeMetadata(t *testing.T) {
 	file := filepath.Join("testdata", "config", "worker-type-metadata.json")
-	config, err := loadConfig(file, false)
+	config, err := loadConfig(file, false, false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -123,7 +123,7 @@ func TestWorkerTypeMetadata(t *testing.T) {
 
 func TestBoolAsString(t *testing.T) {
 	file := filepath.Join("testdata", "config", "bool-as-string.json")
-	_, err := loadConfig(file, false)
+	_, err := loadConfig(file, false, false)
 	if err == nil {
 		t.Fatal("Was expecting to get an error back due to a bool being specified as a string, but didn't get one!")
 	}

--- a/gcp.go
+++ b/gcp.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/taskcluster/generic-worker/gwconfig"
+	"github.com/taskcluster/httpbackoff"
+)
+
+var (
+	// not a const, because in testing we swap this out
+	GcpMetadataBaseURL = "http://metadata.google.internal/computeMetadata/v1/"
+)
+
+type GcpUserData struct {
+	WorkerType         string `json:"workerType"`
+	WorkerGroup        string `json:"workerGroup"`
+	ProvisionerID      string `json:"provisionerId"`
+	CredentialUrl      string `json:"credentialUrl"`
+	Audience           string `json:"audience"`
+	SigningKeyLocation string `json:"signingKeyLocation"`
+
+	// TODO: Remove these both
+	AuthBaseURL  string `json:"authBaseUrl"`
+	QueueBaseURL string `json:"queueBaseUrl"`
+}
+
+type CredentialRequestData struct {
+	Token string `json:"token"`
+}
+
+type TaskclusterCreds struct {
+	AccessToken string `json:"accessToken"`
+	ClientID    string `json:"clientId"`
+	Certificate string `json:"certificate"`
+}
+
+func queryGcpMetaData(client *http.Client, path string) (string, error) {
+	req, err := http.NewRequest("GET", GcpMetadataBaseURL+path, nil)
+
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add("Metadata-Flavor", "Google")
+
+	resp, _, err := httpbackoff.ClientDo(client, req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	content, err := ioutil.ReadAll(resp.Body)
+	return string(content), err
+}
+
+func updateConfigWithGcpSettings(c *gwconfig.Config) error {
+	log.Print("Querying GCP Metadata to get default worker type config settings...")
+	// these are just default values, will be overwritten if set in worker type config
+	c.ShutdownMachineOnInternalError = true
+	c.ShutdownMachineOnIdle = true
+
+	client := &http.Client{}
+	userDataString, err := queryGcpMetaData(client, "instance/attributes/config")
+	if err != nil {
+		return err
+	}
+
+	var userData GcpUserData
+	err = json.Unmarshal([]byte(userDataString), &userData)
+	if err != nil {
+		return err
+	}
+
+	c.ProvisionerID = userData.ProvisionerID
+	c.WorkerType = userData.WorkerType
+	c.WorkerGroup = userData.WorkerGroup
+
+	// TODO: Don't do this anymore
+	c.AuthBaseURL = userData.AuthBaseURL
+	c.QueueBaseURL = userData.QueueBaseURL
+	c.SigningKeyLocation = userData.SigningKeyLocation
+
+	// Now we get taskcluster credentials via instance identity
+	// TODO: Disable getting instance identity after first run
+	audience := userData.Audience
+	instanceIDPath := fmt.Sprintf("instance/service-accounts/default/identity?audience=%s&format=full", audience)
+	instanceIDToken, err := queryGcpMetaData(client, instanceIDPath)
+	if err != nil {
+		return err
+	}
+
+	data := CredentialRequestData{Token: instanceIDToken}
+	reqData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	dataBuffer := bytes.NewBuffer(reqData)
+
+	credentialUrl := userData.CredentialUrl
+	req, err := http.NewRequest("POST", credentialUrl, dataBuffer)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, _, err := httpbackoff.ClientDo(client, req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var creds TaskclusterCreds
+	err = json.Unmarshal([]byte(content), &creds)
+	if err != nil {
+		return err
+	}
+
+	c.AccessToken = creds.AccessToken
+	c.ClientID = creds.ClientID
+	c.Certificate = creds.Certificate
+
+	gcpMetadata := map[string]interface{}{}
+	for _, path := range []string{
+		"instance/image",
+		"instance/id",
+		"instance/machine-type",
+		"instance/network-interfaces/0/access-configs/0/external-ip",
+		"instance/zone",
+		"instance/hostname",
+		"instance/network-interfaces/0/ip",
+	} {
+		key := path[strings.LastIndex(path, "/")+1:]
+		value, err := queryGcpMetaData(client, path)
+		if err != nil {
+			return err
+		}
+		gcpMetadata[key] = value
+	}
+	c.WorkerTypeMetadata["gcp"] = gcpMetadata
+	c.WorkerID = gcpMetadata["id"].(string)
+	c.PublicIP = net.ParseIP(gcpMetadata["external-ip"].(string))
+	c.PrivateIP = net.ParseIP(gcpMetadata["ip"].(string))
+	c.InstanceID = gcpMetadata["id"].(string)
+	c.InstanceType = gcpMetadata["machine-type"].(string)
+	c.AvailabilityZone = gcpMetadata["zone"].(string)
+
+	// TODO: Fetch these from secrets
+	c.LiveLogSecret = "foobar"
+
+	return nil
+}

--- a/gcp_helper_test.go
+++ b/gcp_helper_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/taskcluster/slugid-go/slugid"
+)
+
+type MockGCPProvisionedEnvironment struct {
+}
+
+func (m *MockGCPProvisionedEnvironment) Setup(t *testing.T) func() {
+	teardown := setupEnvironment(t)
+	workerType := slugid.Nice()
+	configureForAws = false
+	configureForGcp = true
+	oldGcpMetadataBaseURL := GcpMetadataBaseURL
+	GcpMetadataBaseURL = "http://localhost:13243/computeMetadata/v1/"
+
+	// Create custom *http.ServeMux rather than using http.DefaultServeMux, so
+	// registered handler functions won't interfere with future tests that also
+	// use http.DefaultServeMux.
+	ec2MetadataHandler := http.NewServeMux()
+	ec2MetadataHandler.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+
+		// simulate gce provider concept endpoints
+
+		case "/gce-thing/credentials":
+			resp := map[string]interface{}{
+				"clientId":    os.Getenv("TASKCLUSTER_CLIENT_ID"),
+				"certificate": os.Getenv("TASKCLUSTER_CERTIFICATE"),
+				"accessToken": os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
+			}
+			WriteJSON(t, w, resp)
+
+		// simulate GCP endpoints
+
+		case "/computeMetadata/v1/instance/attributes/config":
+			resp := map[string]interface{}{
+				"workerType":         workerType,
+				"workerGroup":        "workers",
+				"provisionerId":      "test-provisioner",
+				"credentialUrl":      "http://localhost:13243/gce-thing/credentials",
+				"audience":           "plants",
+				"signingKeyLocation": filepath.Join(testdataDir, "private-opengpg-key"),
+				"authBaseUrl":        "http://localhost:13243/auth",
+				"queueBaseUrl":       "http://localhost:13243/queue",
+			}
+			WriteJSON(t, w, resp)
+		case "/computeMetadata/v1/instance/service-accounts/default/identity":
+			fmt.Fprintf(w, "sekrit-token")
+		case "/computeMetadata/v1/instance/image":
+			fmt.Fprintf(w, "fancy-generic-worker-image")
+		case "/computeMetadata/v1/instance/id":
+			fmt.Fprintf(w, "some-id")
+		case "/computeMetadata/v1/instance/machine-type":
+			fmt.Fprintf(w, "n1-standard")
+		case "/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip":
+			fmt.Fprintf(w, "1.2.3.4")
+		case "/computeMetadata/v1/instance/zone":
+			fmt.Fprintf(w, "us-west1")
+		case "/computeMetadata/v1/instance/hostname":
+			fmt.Fprintf(w, "1-2-3-4-at.google.com")
+		case "/computeMetadata/v1/instance/network-interfaces/0/ip":
+			fmt.Fprintf(w, "10.10.10.10")
+
+		default:
+			w.WriteHeader(400)
+			fmt.Fprintf(w, "Cannot serve URL %v", req.URL)
+			t.Fatalf("Cannot serve URL %v", req.URL)
+		}
+	})
+	s := &http.Server{
+		Addr:           "localhost:13243",
+		Handler:        ec2MetadataHandler,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+	go func() {
+		s.ListenAndServe()
+		t.Log("HTTP server for mock Provisioner and GCP metadata endpoints stopped")
+	}()
+	var err error
+	config, err = loadConfig(filepath.Join(testdataDir, t.Name(), "generic-worker.config"), false, true)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	return func() {
+		teardown()
+		err := s.Shutdown(context.Background())
+		if err != nil {
+			t.Fatalf("Error shutting down http server: %v", err)
+		}
+		GcpMetadataBaseURL = oldGcpMetadataBaseURL
+		configureForGcp = false
+	}
+}

--- a/gcp_test.go
+++ b/gcp_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGcpWorkerTypeMetadata(t *testing.T) {
+	m := &MockGCPProvisionedEnvironment{}
+	defer m.Setup(t)()
+	md := config.WorkerTypeMetadata
+	gcp := md["gcp"].(map[string]interface{})
+	actual := gcp["id"].(string)
+	expected := "some-id"
+	if actual != expected {
+		t.Fatalf("Was expecting machine id '%v' but got '%v'", expected, actual)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ var (
 	cwd = CwdOrPanic()
 	// Whether we are running under the aws provisioner
 	configureForAws bool
+	// Whether we are running in GCP
+	configureForGcp bool
 	// General platform independent user settings, such as home directory, username...
 	// Platform specific data should be managed in plat_<platform>.go files
 	taskContext = &TaskContext{}
@@ -82,11 +84,11 @@ and reports back results to the queue.
 
   Usage:
     generic-worker run                      [--config         CONFIG-FILE]
-                                            [--configure-for-aws]
+                                            [--configure-for-aws | --configure-for-gcp]
     generic-worker install service          [--nssm           NSSM-EXE]
                                             [--service-name   SERVICE-NAME]
                                             [--config         CONFIG-FILE]
-                                            [--configure-for-aws]
+                                            [--configure-for-aws | --configure-for-gcp]
     generic-worker show-payload-schema
     generic-worker new-openpgp-keypair      --file PRIVATE-KEY-FILE
     generic-worker grant-winsta-access      --sid SID
@@ -135,6 +137,9 @@ and reports back results to the queue.
                                             to self-configure, based on AWS metadata, information
                                             from the provisioner, and the worker type definition
                                             that the provisioner holds for the worker type.
+    --configure-for-gcp                     This will create the CONFIG-FILE for a GCP
+                                            installation by querying the GCP environment
+                                            and setting appropriate values.
     --nssm NSSM-EXE                         The full path to nssm.exe to use for installing
                                             the service.
                                             [default: C:\nssm-2.24\win64\nssm.exe]
@@ -402,6 +407,7 @@ func main() {
 
 	case arguments["run"]:
 		configureForAws = arguments["--configure-for-aws"].(bool)
+		configureForGcp = arguments["--configure-for-gcp"].(bool)
 		configFile = arguments["--config"].(string)
 		absConfigFile, err := filepath.Abs(configFile)
 		if err != nil {
@@ -410,7 +416,7 @@ func main() {
 			os.Exit(int(CANT_LOAD_CONFIG))
 		}
 		configFile = absConfigFile
-		config, err = loadConfig(configFile, configureForAws)
+		config, err = loadConfig(configFile, configureForAws, configureForGcp)
 		// persist before checking for error, so we can see what the problem was...
 		if config != nil {
 			config.Persist(configFile)
@@ -465,7 +471,7 @@ func main() {
 	}
 }
 
-func loadConfig(filename string, queryUserData bool) (*gwconfig.Config, error) {
+func loadConfig(filename string, queryAwsUserData bool, queryGcpMetaData bool) (*gwconfig.Config, error) {
 	// TODO: would be better to have a json schema, and also define defaults in
 	// only one place if possible (defaults also declared in `usage`)
 
@@ -500,10 +506,12 @@ func loadConfig(filename string, queryUserData bool) (*gwconfig.Config, error) {
 		WorkerTypeMetadata:             map[string]interface{}{},
 	}
 
-	// now overlay with data from amazon, if applicable
-	if queryUserData {
-		// don't check errors, since maybe secrets are gone, but maybe we had them already from first run...
+	// now overlay with data from amazon/gcp, if applicable
+	// don't check errors, since maybe secrets are gone, but maybe we had them already from first run...
+	if queryAwsUserData {
 		updateConfigWithAmazonSettings(c)
+	} else if queryGcpMetaData {
+		updateConfigWithGcpSettings(c)
 	}
 
 	configFileAbs, err := filepath.Abs(filename)

--- a/plat_windows.go
+++ b/plat_windows.go
@@ -425,17 +425,21 @@ func install(arguments map[string]interface{}) (err error) {
 		nssm := convertNilToEmptyString(arguments["--nssm"])
 		serviceName := convertNilToEmptyString(arguments["--service-name"])
 		configureForAws := arguments["--configure-for-aws"].(bool)
+		configureForGcp := arguments["--configure-for-gcp"].(bool)
 		dir := filepath.Dir(exePath)
-		return deployService(configFile, nssm, serviceName, exePath, dir, configureForAws)
+		return deployService(configFile, nssm, serviceName, exePath, dir, configureForAws, configureForGcp)
 	}
 	log.Fatal("Unknown install target - only 'service' is allowed")
 	return nil
 }
 
-func CreateRunGenericWorkerBatScript(batScriptFilePath string, configureForAws bool) error {
+func CreateRunGenericWorkerBatScript(batScriptFilePath string, configureForAws bool, configureForGcp bool) error {
 	runCommand := `.\generic-worker.exe run`
 	if configureForAws {
 		runCommand += ` --configure-for-aws`
+	}
+	if configureForGcp {
+		runCommand += ` --configure-for-gcp`
 	}
 	runCommand += ` > .\generic-worker.log 2>&1`
 	batScriptContents := []byte(strings.Join([]string{
@@ -488,9 +492,9 @@ func SetAutoLogin(user *runtime.OSUser) error {
 // is required to install the service, specified as a file system path. The
 // serviceName is the service name given to the newly created service. if the
 // service already exists, it is simply updated.
-func deployService(configFile, nssm, serviceName, exePath, dir string, configureForAws bool) error {
+func deployService(configFile, nssm, serviceName, exePath, dir string, configureForAws bool, configureForGcp bool) error {
 	targetScript := filepath.Join(filepath.Dir(exePath), "run-generic-worker.bat")
-	err := CreateRunGenericWorkerBatScript(targetScript, configureForAws)
+	err := CreateRunGenericWorkerBatScript(targetScript, configureForAws, configureForGcp)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This _works_ but might not be the way we want to do it in the future. Please feel free to have me change how anything works.

This works in concert with https://github.com/imbstack/taskcluster-gce-provider-concept.

Specifically the tc creds comes from [here](https://github.com/imbstack/taskcluster-gce-provider-concept/blob/master/src/api.js)

We can wait on merging this until rootUrl support exists.