### PR TITLE
Bug 1469614 - work in progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ and reports back results to the queue.
         ** OPTIONAL ** properties
         =========================
 
-          authBaseURL                       The base URL for API calls to the auth service.
           availabilityZone                  The EC2 availability zone of the worker.
           cachesDir                         The directory where task caches should be stored on
                                             the worker. The directory will be created if it does
@@ -249,14 +248,9 @@ and reports back results to the queue.
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after
                                             this many tasks, exit. [default: 0]
           privateIP                         The private IP of the worker, used by chain of trust.
-          provisionerBaseURL                The base URL for API calls to the provisioner in
-                                            order to determine if there is a new deploymentId.
           provisionerId                     The taskcluster provisioner which is taking care
                                             of provisioning environments with generic-worker
                                             running on them. [default: test-provisioner]
-          purgeCacheBaseURL                 The base URL for API calls to the purge cache
-                                            service.
-          queueBaseURL                      The base URL for API calls to the queue service.
           region                            The EC2 region of the worker.
           requiredDiskSpaceMegabytes        The garbage collector will ensure at least this
                                             number of megabytes of disk space are available
@@ -304,6 +298,8 @@ and reports back results to the queue.
                                             [default: taskcluster-proxy]
           taskclusterProxyPort              Port number for taskcluster-proxy HTTP requests.
                                             [default: 80]
+          taskclusterRootURL                Root URL of taskcluster cluster that this worker
+                                            should interact with. [default: https://taskcluster.net]
           tasksDir                          The location where task directories should be
                                             created on the worker. [default: /Users]
           workerGroup                       Typically this would be an aws region - an

--- a/aws_helper_test.go
+++ b/aws_helper_test.go
@@ -95,7 +95,7 @@ func (m *MockAWSProvisionedEnvironment) Setup(t *testing.T) func() {
 				"price":               3.02,
 				"launchSpecGenerated": time.Now(),
 				"lastModified":        time.Now().Add(time.Minute * -30),
-				"provisionerBaseUrl":  "http://localhost:13243/provisioner",
+				"taskclusterRootUrl":  "http://acme.com:43243/demo",
 				"securityToken":       "12345",
 			}
 			WriteJSON(t, w, resp)

--- a/gwconfig/config.go
+++ b/gwconfig/config.go
@@ -9,13 +9,13 @@ import (
 	"runtime"
 
 	"github.com/taskcluster/generic-worker/fileutil"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 )
 
 type (
 	// Generic Worker config
 	Config struct {
 		AccessToken                    string                 `json:"accessToken"`
-		AuthBaseURL                    string                 `json:"authBaseURL"`
 		AvailabilityZone               string                 `json:"availabilityZone"`
 		CachesDir                      string                 `json:"cachesDir"`
 		Certificate                    string                 `json:"certificate"`
@@ -36,11 +36,8 @@ type (
 		LiveLogSecret                  string                 `json:"livelogSecret"`
 		NumberOfTasksToRun             uint                   `json:"numberOfTasksToRun"`
 		PrivateIP                      net.IP                 `json:"privateIP"`
-		ProvisionerBaseURL             string                 `json:"provisionerBaseURL"`
 		ProvisionerID                  string                 `json:"provisionerId"`
 		PublicIP                       net.IP                 `json:"publicIP"`
-		PurgeCacheBaseURL              string                 `json:"purgeCacheBaseURL"`
-		QueueBaseURL                   string                 `json:"queueBaseURL"`
 		Region                         string                 `json:"region"`
 		RequiredDiskSpaceMegabytes     uint                   `json:"requiredDiskSpaceMegabytes"`
 		RunAfterUserCreation           string                 `json:"runAfterUserCreation"`
@@ -52,6 +49,7 @@ type (
 		Subdomain                      string                 `json:"subdomain"`
 		TaskclusterProxyExecutable     string                 `json:"taskclusterProxyExecutable"`
 		TaskclusterProxyPort           uint16                 `json:"taskclusterProxyPort"`
+		TaskclusterRootURL             string                 `json:"taskclusterRootURL"`
 		TasksDir                       string                 `json:"tasksDir"`
 		WorkerGroup                    string                 `json:"workerGroup"`
 		WorkerID                       string                 `json:"workerId"`
@@ -103,6 +101,7 @@ func (c *Config) Validate() error {
 		{value: c.SigningKeyLocation, name: "signingKeyLocation", disallowed: ""},
 		{value: c.Subdomain, name: "subdomain", disallowed: ""},
 		{value: c.TasksDir, name: "tasksDir", disallowed: ""},
+		{value: c.TaskclusterRootURL, name: "taskclusterRootURL", disallowed: ""},
 		{value: c.WorkerGroup, name: "workerGroup", disallowed: ""},
 		{value: c.WorkerID, name: "workerId", disallowed: ""},
 		{value: c.WorkerType, name: "workerType", disallowed: ""},
@@ -124,4 +123,13 @@ func (c *Config) Validate() error {
 
 func (err MissingConfigError) Error() string {
 	return "Config setting \"" + err.Setting + "\" has not been defined"
+}
+
+func (c *Config) WorkerCredentials() *tcclient.Credentials {
+	return &tcclient.Credentials{
+		ClientID:    c.ClientID,
+		AccessToken: c.AccessToken,
+		Certificate: c.Certificate,
+		RootURL:     c.TaskclusterRootURL,
+	}
 }

--- a/livelog.go
+++ b/livelog.go
@@ -14,6 +14,7 @@ import (
 	"github.com/taskcluster/stateless-dns-go/hostname"
 	"github.com/taskcluster/taskcluster-base-go/scopes"
 	tcclient "github.com/taskcluster/taskcluster-client-go"
+	tcurls "github.com/taskcluster/taskcluster-lib-urls"
 )
 
 var (
@@ -131,7 +132,7 @@ func (l *LiveLogTask) Stop(err *ExecutionErrors) {
 		log.Printf("WARNING: could not terminate livelog writer: %s", errTerminate)
 	}
 	log.Printf("Redirecting %v to %v", livelogName, logName)
-	logURL := fmt.Sprintf("%v/task/%v/runs/%v/artifacts/%v", queue.BaseURL, l.task.TaskID, l.task.RunID, logName)
+	logURL := tcurls.API(queue.Credentials.RootURL, "queue", "v1", fmt.Sprintf("/task/%v/runs/%v/artifacts/%v", l.task.TaskID, l.task.RunID, logName))
 	err.add(l.task.uploadArtifact(
 		&RedirectArtifact{
 			BaseArtifact: &BaseArtifact{

--- a/mounts.go
+++ b/mounts.go
@@ -151,8 +151,7 @@ func (cm *CacheMap) LoadFromFile(stateFile string, cacheDir string) {
 func (feature *MountsFeature) Initialise() error {
 	fileCaches.LoadFromFile("file-caches.json", config.CachesDir)
 	directoryCaches.LoadFromFile("directory-caches.json", config.DownloadsDir)
-	pc = tcpurgecache.New(nil)
-	pc.BaseURL = config.PurgeCacheBaseURL
+	pc = tcpurgecache.New(&tcclient.Credentials{RootURL: config.TaskclusterRootURL})
 	return nil
 }
 

--- a/sentry.go
+++ b/sentry.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	raven "github.com/getsentry/raven-go"
-	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/tcauth"
 )
 
@@ -16,13 +15,8 @@ func ReportCrashToSentry(r interface{}) {
 		return
 	}
 	Auth := tcauth.New(
-		&tcclient.Credentials{
-			ClientID:    config.ClientID,
-			AccessToken: config.AccessToken,
-			Certificate: config.Certificate,
-		},
+		config.WorkerCredentials(),
 	)
-	Auth.BaseURL = config.AuthBaseURL
 	res, err := Auth.SentryDSN(config.SentryProject)
 	if err != nil {
 		log.Printf("WARNING: Could not get sentry DSN: %v", err)

--- a/taskcluster_proxy.go
+++ b/taskcluster_proxy.go
@@ -60,6 +60,7 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 			AccessToken: l.task.TaskClaimResponse.Credentials.AccessToken,
 			Certificate: l.task.TaskClaimResponse.Credentials.Certificate,
 			ClientID:    l.task.TaskClaimResponse.Credentials.ClientID,
+			RootURL:     config.TaskclusterRootURL,
 		},
 		l.task.TaskID,
 	)

--- a/taskstatus.go
+++ b/taskstatus.go
@@ -171,6 +171,7 @@ func (tsm *TaskStatusManager) reclaim() error {
 				ClientID:    tcrsp.Credentials.ClientID,
 				AccessToken: tcrsp.Credentials.AccessToken,
 				Certificate: tcrsp.Credentials.Certificate,
+				RootURL:     config.TaskclusterRootURL,
 			})
 			task.queueMux.Unlock()
 			tsm.status = tcrsp.Status

--- a/tcproxy/tcproxy.go
+++ b/tcproxy/tcproxy.go
@@ -31,6 +31,7 @@ func New(taskclusterProxyExecutable string, httpPort uint16, creds *tcclient.Cre
 		"--client-id", creds.ClientID,
 		"--access-token", creds.AccessToken,
 		"--ip-address", "127.0.0.1",
+		"--taskcluster-root-url", creds.RootURL,
 	}
 	if creds.Certificate != "" {
 		args = append(args, "--certificate", creds.Certificate)

--- a/tcproxy/tcproxy_test.go
+++ b/tcproxy/tcproxy_test.go
@@ -22,6 +22,7 @@ func TestTaskclusterProxy(t *testing.T) {
 		ClientID:         os.Getenv("TASKCLUSTER_CLIENT_ID"),
 		AccessToken:      os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
 		Certificate:      os.Getenv("TASKCLUSTER_CERTIFICATE"),
+		RootURL:          os.Getenv("TASKCLUSTER_ROOT_URL"),
 		AuthorizedScopes: []string{"queue:get-artifact:SampleArtifacts/_/X.txt"},
 	}
 	ll, err := New(executable, 34569, creds, "")


### PR DESCRIPTION
With this PR, `generic-worker` has new config property `taskclusterRootURL` in order to be interoperable with different taskcluster deployments.

Work in progress, since this depends on the client updates (i.e. depends on taskcluster/taskcluster-client-go#37).