### PR TITLE
Bug 1479415 - tasks executing a non-executable file should resolve as failed, not exception

### DIFF
--- a/helper_all-unix-style_test.go
+++ b/helper_all-unix-style_test.go
@@ -143,3 +143,7 @@ func copyTestdataFileTo(src, dest string) [][]string {
 		},
 	}
 }
+
+func singleCommandNoArgs(command string) [][]string {
+	return [][]string{{command}}
+}

--- a/helper_windows_test.go
+++ b/helper_windows_test.go
@@ -108,3 +108,7 @@ func copyTestdataFileTo(src, dest string) []string {
 		"copy \"" + sourceFile + "\" \"" + destFile + "\"",
 	}
 }
+
+func singleCommandNoArgs(command string) []string {
+	return []string{command}
+}


### PR DESCRIPTION
See [bug 1479415](https://bugzil.la/1479415) for context.