### PR TITLE
remove 'git clean' command from build process

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -105,8 +105,6 @@ fi
 find "${GOPATH}/bin" -name 'generic-worker*'
 
 CGO_ENABLED=0 go get github.com/taskcluster/livelog
-# capital X here ... we only want to delete things that are ignored!
-git clean -fdX
 
 if $TEST; then
   go get github.com/taskcluster/taskcluster-proxy


### PR DESCRIPTION
We are not sure why this was here - perhaps a copy-paste error?  But it
deletes local files that I would like it not to delete!