### PR TITLE
Bug 1469614 - use updated taskcluster-client-go in generic-worker

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -195,11 +195,13 @@ func updateConfigWithAmazonSettings(c *gwconfig.Config) error {
 	c.ProvisionerID = userData.ProvisionerID
 	c.Region = userData.Region
 	c.ProvisionerBaseURL = userData.ProvisionerBaseURL
+	c.RootURL = userData.TaskclusterRootURL
 
-	awsprov := tcawsprovisioner.AwsProvisioner{
-		Authenticate: false,
-		BaseURL:      userData.ProvisionerBaseURL,
-	}
+	// We need an AWS Provisioner client for fetching taskcluster credentials.
+	// Ensure auth is disabled in client, since we don't have credentials yet.
+	awsprov := c.AWSProvisioner()
+	awsprov.Authenticate = false
+	awsprov.Credentials = nil
 
 	secToken, getErr := awsprov.GetSecret(userData.SecurityToken)
 	// remove secrets even if we couldn't retrieve them!
@@ -214,7 +216,6 @@ func updateConfigWithAmazonSettings(c *gwconfig.Config) error {
 	c.AccessToken = secToken.Credentials.AccessToken
 	c.Certificate = secToken.Credentials.Certificate
 	c.ClientID = secToken.Credentials.ClientID
-	c.RootURL = userData.TaskclusterRootURL
 	c.WorkerGroup = userData.Region
 	c.WorkerType = userData.WorkerType
 

--- a/aws_helper_test.go
+++ b/aws_helper_test.go
@@ -93,7 +93,7 @@ func (m *MockAWSProvisionedEnvironment) Setup(t *testing.T) func() {
 				"instanceType":        "p3.teenyweeny",
 				"spotBid":             3.5,
 				"price":               3.02,
-				"taskclusterRootUrl":  "http://localhost:13243",
+				"taskclusterRootUrl":  os.Getenv("TASKCLUSTER_ROOT_URL"), // don't use tcclient.RootURLFromEnvVars() since we don't want ClientID of CI
 				"launchSpecGenerated": time.Now(),
 				"lastModified":        time.Now().Add(time.Minute * -30),
 				"provisionerBaseUrl":  "http://localhost:13243/provisioner",

--- a/gwconfig/config.go
+++ b/gwconfig/config.go
@@ -9,6 +9,11 @@ import (
 	"runtime"
 
 	"github.com/taskcluster/generic-worker/fileutil"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/tcauth"
+	"github.com/taskcluster/taskcluster-client-go/tcawsprovisioner"
+	"github.com/taskcluster/taskcluster-client-go/tcpurgecache"
+	"github.com/taskcluster/taskcluster-client-go/tcqueue"
 )
 
 type (
@@ -126,4 +131,49 @@ func (c *Config) Validate() error {
 
 func (err MissingConfigError) Error() string {
 	return "Config setting \"" + err.Setting + "\" has not been defined"
+}
+
+func (c *Config) Credentials() *tcclient.Credentials {
+	return &tcclient.Credentials{
+		AccessToken: c.AccessToken,
+		ClientID:    c.ClientID,
+		Certificate: c.Certificate,
+	}
+}
+
+func (c *Config) Auth() *tcauth.Auth {
+	auth := tcauth.New(c.Credentials(), c.RootURL)
+	// If authBaseURL provided, it should take precedence over rootURL
+	if c.AuthBaseURL != "" {
+		auth.BaseURL = c.AuthBaseURL
+	}
+	return auth
+}
+
+func (c *Config) Queue() *tcqueue.Queue {
+	queue := tcqueue.New(c.Credentials(), c.RootURL)
+	// If queueBaseURL provided, it should take precedence over rootURL
+	if c.QueueBaseURL != "" {
+		queue.BaseURL = c.QueueBaseURL
+	}
+	return queue
+}
+
+func (c *Config) AWSProvisioner() *tcawsprovisioner.AwsProvisioner {
+	awsProvisioner := tcawsprovisioner.New(c.Credentials())
+	awsProvisioner.BaseURL = tcclient.BaseURL(c.RootURL, "aws-provisioner", "v1")
+	// If provisionerBaseURL provided, it should take precedence over rootURL
+	if c.ProvisionerBaseURL != "" {
+		awsProvisioner.BaseURL = c.ProvisionerBaseURL
+	}
+	return awsProvisioner
+}
+
+func (c *Config) PurgeCache() *tcpurgecache.PurgeCache {
+	purgeCache := tcpurgecache.New(c.Credentials(), c.RootURL)
+	// If purgeCacheBaseURL provided, it should take precedence over rootURL
+	if c.PurgeCacheBaseURL != "" {
+		purgeCache.BaseURL = c.PurgeCacheBaseURL
+	}
+	return purgeCache
 }

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -234,4 +235,89 @@ func TestNonExecutableBinaryFailsTask(t *testing.T) {
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
+}
+
+// TestRemoveTaskDirs creates a temp directory containing files and folders
+// whose names begin with 'task_', other files and folders that don't, then
+// calls removeTaskDirs(tempDir), and tests that only folders that started with
+// 'task_' were deleted and that the other files and folders were not.
+func TestRemoveTaskDirs(t *testing.T) {
+	d, err := ioutil.TempDir("", "TestRemoveTaskDirs")
+	if err != nil {
+		t.Fatalf("Could not create temp directory: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(d)
+		if err != nil {
+			t.Fatalf("Could not remove temp dir TestRemoveTaskDirs: %v", err)
+		}
+	}()
+	for _, dir := range []string{
+		"task_12345",     // should be deleted
+		"task_task_test", // should be deleted
+		"testt_12345",    // should remain
+		"bfdnbdfd",       // should remain
+	} {
+		err = os.MkdirAll(filepath.Join(d, dir), 0777)
+		if err != nil {
+			t.Fatalf("Could not create temp %v directory: %v", dir, err)
+		}
+	}
+	for _, file := range []string{
+		"task_23456",                         // should remain
+		"task_best_vest",                     // should remain
+		"testt_65536",                        // should remain
+		"applesnpears",                       // should remain
+		filepath.Join("task_12345", "abcde"), // should be deleted
+	} {
+		err = ioutil.WriteFile(filepath.Join(d, file), []byte("hello world"), 0777)
+		if err != nil {
+			t.Fatalf("Could not write %v file: %v", file, err)
+		}
+	}
+	err = removeTaskDirs(d)
+	if err != nil {
+		t.Fatalf("Could not remove task directories: %v", err)
+	}
+	taskDirsParent, err := os.Open(d)
+	if err != nil {
+		t.Fatalf("Could not open %v directory: %v", d, err)
+	}
+	defer func() {
+		err := taskDirsParent.Close()
+		if err != nil {
+			t.Fatalf("Could not close %v directory: %v", d, err)
+		}
+	}()
+	fi, err := taskDirsParent.Readdir(-1)
+	if err != nil {
+		t.Fatalf("Error reading directory listing of %v: %v", d, err)
+	}
+	expectedDirs := map[string]bool{
+		"testt_12345": true,
+		"bfdnbdfd":    true,
+	}
+	expectedFiles := map[string]bool{
+		"task_23456":     true,
+		"task_best_vest": true,
+		"testt_65536":    true,
+		"applesnpears":   true,
+	}
+	if len(fi) != len(expectedDirs)+len(expectedFiles) {
+		for _, file := range fi {
+			t.Logf("File %v", file.Name())
+		}
+		t.Fatalf("Expected to find %v directory records (%v dirs + %v files) but found %v", len(expectedDirs)+len(expectedFiles), len(expectedDirs), len(expectedFiles), len(fi))
+	}
+	for _, file := range fi {
+		if file.IsDir() {
+			if !expectedDirs[file.Name()] {
+				t.Fatalf("Didn't expect to find dir %v but found it under temp dir %v", file.Name(), d)
+			}
+		} else {
+			if !expectedFiles[file.Name()] {
+				t.Fatalf("Didn't expect to find file %v but found it under temp dir %v", file.Name(), d)
+			}
+		}
+	}
 }

--- a/mounts.go
+++ b/mounts.go
@@ -151,8 +151,7 @@ func (cm *CacheMap) LoadFromFile(stateFile string, cacheDir string) {
 func (feature *MountsFeature) Initialise() error {
 	fileCaches.LoadFromFile("file-caches.json", config.CachesDir)
 	directoryCaches.LoadFromFile("directory-caches.json", config.DownloadsDir)
-	pc = tcpurgecache.New(nil)
-	pc.BaseURL = config.PurgeCacheBaseURL
+	pc = config.PurgeCache()
 	return nil
 }
 
@@ -843,7 +842,7 @@ func (bc *Base64Content) Download(task *TaskRun) (file string, sha256 string, er
 }
 
 func (bc *Base64Content) String() string {
-	return "Base64 (" +  bc.Base64 + ")"
+	return "Base64 (" + bc.Base64 + ")"
 }
 
 func (bc *Base64Content) UniqueKey() string {

--- a/sentry.go
+++ b/sentry.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 
 	raven "github.com/getsentry/raven-go"
-	tcclient "github.com/taskcluster/taskcluster-client-go"
-	"github.com/taskcluster/taskcluster-client-go/tcauth"
 )
 
 func ReportCrashToSentry(r interface{}) {
@@ -15,14 +13,7 @@ func ReportCrashToSentry(r interface{}) {
 		log.Println("No sentry project defined, not reporting to sentry")
 		return
 	}
-	Auth := tcauth.New(
-		&tcclient.Credentials{
-			ClientID:    config.ClientID,
-			AccessToken: config.AccessToken,
-			Certificate: config.Certificate,
-		},
-	)
-	Auth.BaseURL = config.AuthBaseURL
+	Auth := config.Auth()
 	res, err := Auth.SentryDSN(config.SentryProject)
 	if err != nil {
 		log.Printf("WARNING: Could not get sentry DSN: %v", err)

--- a/sentry.go
+++ b/sentry.go
@@ -31,15 +31,16 @@ func ReportCrashToSentry(r interface{}) {
 		map[string]string{
 			"cleanUpTaskDirs":       strconv.FormatBool(config.CleanUpTaskDirs),
 			"deploymentId":          config.DeploymentID,
-			"instanceType":          config.InstanceType,
-			"runTasksAsCurrentUser": strconv.FormatBool(config.RunTasksAsCurrentUser),
-			"workerGroup":           config.WorkerGroup,
-			"workerId":              config.WorkerID,
-			"workerType":            config.WorkerType,
 			"gwVersion":             version,
 			"gwRevision":            revision,
 			"GOOS":                  runtime.GOOS,
 			"GOARCH":                runtime.GOARCH,
+			"instanceType":          config.InstanceType,
+			"provisionerId":         config.ProvisionerID,
+			"runTasksAsCurrentUser": strconv.FormatBool(config.RunTasksAsCurrentUser),
+			"workerGroup":           config.WorkerGroup,
+			"workerId":              config.WorkerID,
+			"workerType":            config.WorkerType,
 		},
 	)
 }

--- a/taskstatus.go
+++ b/taskstatus.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/taskcluster/taskcluster-client-go"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/tcqueue"
 )
 
@@ -167,11 +167,11 @@ func (tsm *TaskStatusManager) reclaim() error {
 
 			task.TaskReclaimResponse = *tcrsp
 			task.queueMux.Lock()
-			task.Queue = tcqueue.New(&tcclient.Credentials{
+			task.Queue.Credentials = &tcclient.Credentials{
 				ClientID:    tcrsp.Credentials.ClientID,
 				AccessToken: tcrsp.Credentials.AccessToken,
 				Certificate: tcrsp.Credentials.Certificate,
-			})
+			}
 			task.queueMux.Unlock()
 			tsm.status = tcrsp.Status
 			tsm.takenUntil = tcrsp.TakenUntil

--- a/testdata/resolvetask.go
+++ b/testdata/resolvetask.go
@@ -4,11 +4,12 @@ import (
 	"log"
 	"os"
 
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/tcqueue"
 )
 
 func main() {
-	queue := tcqueue.NewFromEnv()
+	queue := tcqueue.New(tcclient.CredentialsFromEnvVars(), os.Getenv("TASKCLUSTER_ROOT_URL"))
 	taskID := os.Getenv("TASK_ID")
 	_, err := queue.CancelTask(taskID)
 	if err != nil {


### PR DESCRIPTION
Hey @jhford,

See [bug 1469614](https://bugzil.la/1469614). This updates generic-worker to use the new taskcluster-client-go that appeared in [bug 1428422](https://bugzil.la/1428422). I may have missed something on this first commit, so let's wait for the CI to complete, and also then I'll check the CI logs to make sure no tests were skipped for any reason. I'll put you up for review as soon as I'm confident it is ready.

Thanks!