### PR TITLE
Bug 1375200 - only update config from aws/gcp if generic worker config not present

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"encoding/json"
-	"net"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/taskcluster/generic-worker/gwconfig"
@@ -57,11 +57,9 @@ func TestInvalidIPConfig(t *testing.T) {
 	if err == nil {
 		t.Fatal("Was expecting to get an error back due to an invalid IP address, but didn't get one!")
 	}
-	switch err.(type) {
-	case *net.ParseError:
-		// all ok
-	default:
-		t.Fatalf("Was expecting an error of type *net.ParseError but received error of type %T", err)
+	expectedErrorText := `invalid IP address: 257.1.2.1`
+	if !strings.Contains(err.Error(), expectedErrorText) {
+		t.Fatalf("Was expecting error text to include %q but it didn't: %v", expectedErrorText, err)
 	}
 }
 
@@ -71,29 +69,20 @@ func TestInvalidJsonConfig(t *testing.T) {
 	if err == nil {
 		t.Fatal("Was expecting to get an error back due to an invalid JSON config, but didn't get one!")
 	}
-	switch err.(type) {
-	case *json.SyntaxError:
-		// all ok
-	default:
-		t.Fatalf("Was expecting an error of type *json.SyntaxError but received error of type %T", err)
+	expectedErrorText := `invalid character '"' after object key:value pair`
+	if !strings.Contains(err.Error(), expectedErrorText) {
+		t.Fatalf("Was expecting error text to include %q but it didn't: %v", expectedErrorText, err)
 	}
 }
 
 func TestMissingConfigFile(t *testing.T) {
 	file := filepath.Join("testdata", "config", "non-existent-json.json")
-	config, err := loadConfig(file, false, false)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = config.Validate()
+	_, err := loadConfig(file, false, false)
 	if err == nil {
-		t.Fatal("Was expecting to get an error back due to an invalid IP address, but didn't get one!")
+		t.Fatal("Was expecting an error when loading non existent config file without --configure-for-{aws,gcp} set")
 	}
-	switch err.(type) {
-	case gwconfig.MissingConfigError:
-		// all ok
-	default:
-		t.Fatalf("Was expecting an error of type gwconfig.MissingConfigError but received error of type %T", err)
+	if _, isPathError := err.(*os.PathError); !isPathError {
+		t.Fatalf("Was expecting an error of type *os.PathError but received error %#v", err)
 	}
 }
 
@@ -127,10 +116,8 @@ func TestBoolAsString(t *testing.T) {
 	if err == nil {
 		t.Fatal("Was expecting to get an error back due to a bool being specified as a string, but didn't get one!")
 	}
-	switch err.(type) {
-	case *json.UnmarshalTypeError:
-		// all ok
-	default:
-		t.Fatalf("Was expecting an error of type *json.UnmarshalTypeError but received error of type %T", err)
+	expectedErrorText := `cannot unmarshal string into Go struct field Config.runTasksAsCurrentUser of type bool`
+	if !strings.Contains(err.Error(), expectedErrorText) {
+		t.Fatalf("Was expecting error text to include %q but it didn't: %v", expectedErrorText, err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -581,7 +581,7 @@ func loadConfig(filename string, queryAWSUserData bool, queryGCPMetaData bool) (
 			return nil, err
 		}
 		if err != nil {
-			return nil, fmt.Errorf("FATAL: problem loading generic worker config file or retrieving config from aws/gcp: %v", err)
+			return nil, fmt.Errorf("FATAL: problem retrieving config/secrets from aws/gcp: %v", err)
 		}
 	} else {
 		buffer := bytes.NewBuffer(configData)


### PR DESCRIPTION
In other words, we should only inspect aws/gcp metadata if generic-worker config file is missing, which happens on first run of the worker. On subsequent runs (e.g. after a reboot) the config file is present and written to disk, so no metadata queries or calls to the AWS Provisioner are made.

This means you now can't have a subset of generic-worker config on the filesystem, and merge it with what you get from the metadata service / secrets service - but that is probably a good thing. Previously you could do this, but then it would have been misleading for people looking at the worker type definition, since there would be potentially incorrect config settings there that were getting overridden with what was stored e.g. in the AMI.

Now if you get credentials from the provisioner, you also are forced to get your config from it too. This doesn't prevent someone from burning in their own credentials and config - but maybe we can look at other ways to ensure that.