### PR TITLE
Bug 1436195 - implement exposing services publicly

### DIFF
--- a/expose/expose.go
+++ b/expose/expose.go
@@ -1,0 +1,45 @@
+// Expose serves as an abstract mechanism for exposing local services to the world.
+//
+// It supports both HTTP services (to which it can proxy directly) and
+// plain-old TCP ports, which it exposes via websockets.
+//
+// Exposing starts by creating an Exposer, which can be one of several types depending
+// on available resorces.  That Exposer is then used to create Exposures for specific
+// backend services.  Each Exposure then provides a GetURL method that returns a
+// public URL which will reach the exposed service.
+package expose
+
+import "net/url"
+
+// Exposer provides an interface for exposing services, including configuration
+// and any necessary shared state.  It is intended to exist for the lifetime of
+// the process.
+type Exposer interface {
+	// Expose an HTTP service.  The resulting URL will proxy directly to this
+	// service, including streaming bidirectional communication
+	ExposeHTTP(targetPort uint16) (Exposure, error)
+
+	// Expose a TCP port.  The resulting URL will proxy websocket connections
+	// to the given port.  For each new websocket connection, a new TCP
+	// connection is initiated to the backend service.  The payload of each
+	// incoming websocket message is written to the TCP connection, and all
+	// data read from the TCP connection is written to the websocket.
+	//
+	// Note that TCP is not a message-framed protocol, so callers should not
+	// rely on message boundaries to delimit data transmitted across this
+	// connection.
+	ExposeTCPPort(targetPort uint16) (Exposure, error)
+}
+
+// Exposure is a more ephemeral exposure of a single backend service, derived
+// from Exposer.ExposeHTTP or Exposer.ExposeTCPPort.  It can return a URL
+// for the exposed service, and can be Closed when the service should no
+// longer be exposed.
+type Exposure interface {
+	// Stop this exposure.  Note that any existing connections may continue
+	// to operate.
+	Close() error
+
+	// Get the public URL for this exposure
+	GetURL() *url.URL
+}

--- a/expose/local/local.go
+++ b/expose/local/local.go
@@ -1,0 +1,125 @@
+// Local exposer implementation.  Local exposers are useful for local testing,
+// and simply exposes the URL as given, or (for ExposeTCPPort) proxies a
+// websocket on localhost to the port.
+
+package local
+
+import (
+	"fmt"
+	"net"
+
+	"net/url"
+
+	"github.com/taskcluster/generic-worker/expose"
+	exposeutil "github.com/taskcluster/generic-worker/expose/util"
+)
+
+func New(publicIP net.IP) (expose.Exposer, error) {
+	return &exposer{publicIP}, nil
+}
+
+type exposer struct {
+	publicIP net.IP
+}
+
+// httpExposure exposes an HTTP server
+type httpExposure struct {
+	exposer    *exposer
+	targetPort uint16
+	listener   net.Listener
+	proxy      exposeutil.ExposeProxy
+}
+
+func (exposer *exposer) ExposeHTTP(targetPort uint16) (expose.Exposure, error) {
+	exposure := &httpExposure{exposer: exposer, targetPort: targetPort}
+	err := exposure.start()
+	if err != nil {
+		return nil, err
+	}
+	return exposure, nil
+}
+
+func (exposure *httpExposure) start() error {
+	// allocate a port dynamically by specifying :0
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return err
+	}
+	exposure.listener = listener
+
+	proxy, err := exposeutil.ProxyHTTP(listener, exposure.targetPort)
+	if err != nil {
+		listener.Close()
+		return err
+	}
+
+	exposure.proxy = proxy
+	return nil
+}
+
+func (exposure *httpExposure) Close() error {
+	if exposure.proxy != nil {
+		return exposure.proxy.Close()
+	}
+	return nil
+}
+
+func (exposure *httpExposure) GetURL() *url.URL {
+	_, portStr, _ := net.SplitHostPort(exposure.listener.Addr().String())
+
+	return &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("%s:%s", exposure.exposer.publicIP, portStr),
+	}
+}
+
+// portExposure exposes a port, via a websocket server
+type portExposure struct {
+	exposer    *exposer
+	targetPort uint16
+	listener   net.Listener
+	proxy      exposeutil.ExposeProxy
+}
+
+func (exposer *exposer) ExposeTCPPort(targetPort uint16) (expose.Exposure, error) {
+	exposure := &portExposure{exposer: exposer, targetPort: targetPort}
+	err := exposure.start()
+	if err != nil {
+		return nil, err
+	}
+	return exposure, nil
+}
+
+func (exposure *portExposure) start() error {
+	// allocate a port dynamically by specifying :0
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return err
+	}
+	exposure.listener = listener
+
+	proxy, err := exposeutil.ProxyTCPPort(listener, exposure.targetPort)
+	if err != nil {
+		listener.Close()
+		return err
+	}
+
+	exposure.proxy = proxy
+	return nil
+}
+
+func (exposure *portExposure) Close() error {
+	if exposure.proxy != nil {
+		return exposure.proxy.Close()
+	}
+	return nil
+}
+
+func (exposure *portExposure) GetURL() *url.URL {
+	_, portStr, _ := net.SplitHostPort(exposure.listener.Addr().String())
+
+	return &url.URL{
+		Scheme: "ws",
+		Host:   fmt.Sprintf("%s:%s", exposure.exposer.publicIP, portStr),
+	}
+}

--- a/expose/local/local_test.go
+++ b/expose/local/local_test.go
@@ -1,0 +1,71 @@
+package local
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/taskcluster/generic-worker/expose"
+)
+
+func TestConstructor(t *testing.T) {
+	exposer, err := New(net.ParseIP("127.0.0.1"))
+	if err != nil {
+		t.Fatalf("Constructor returned an error: %v", err)
+	}
+	if exposer == nil {
+		t.Fatalf("Constructor did not return a value")
+	}
+}
+
+func makeExposer(t *testing.T) expose.Exposer {
+	exposer, err := New(net.ParseIP("127.0.0.1"))
+	if err != nil {
+		t.Fatalf("Constructor returned an error: %v", err)
+	}
+	return exposer
+}
+
+func makeTestServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, world")
+	}))
+}
+
+func TestExposeHTTP(t *testing.T) {
+	ts := makeTestServer()
+	defer ts.Close()
+	testURL, _ := url.Parse(ts.URL)
+	_, testPortStr, _ := net.SplitHostPort(testURL.Host)
+	testPort, _ := strconv.Atoi(testPortStr)
+
+	exposer := makeExposer(t)
+	exposure, err := exposer.ExposeHTTP(uint16(testPort))
+	if err != nil {
+		t.Fatalf("ExposeHTTP returned an error: %v", err)
+	}
+	defer exposure.Close()
+
+	gotURL := exposure.GetURL()
+	host, port, _ := net.SplitHostPort(gotURL.Host)
+	assert.Equal(t, "http", gotURL.Scheme, "Should return URL with correct schem")
+	assert.Equal(t, "127.0.0.1", host, "Should return URL with correct host")
+	assert.NotEqual(t, "90", port, "Should return URL with a random port")
+
+	res, err := http.Get(gotURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	greeting, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "Hello, world", string(greeting), "got greeting via proxy")
+}

--- a/expose/util/proxy.go
+++ b/expose/util/proxy.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+)
+
+type ExposeProxy interface {
+	// stop the proxy
+	Close() error
+}
+
+type httpProxy struct {
+	server   *http.Server
+}
+
+// Start a proxy running on all interfaces on this host, at an arbitrary port,
+// forwarding traffic to the given port on localhost.
+func ProxyHTTP(listener net.Listener, targetPort uint16) (ExposeProxy, error) {
+	targetURL, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", targetPort))
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+
+	// We want to support streaming responses that are not detected as such (for
+	// example, a streaming logfile).  So, arrange to flush any buffered data after
+	// 100ms.
+	proxy.FlushInterval = 100 * time.Millisecond
+
+	server := &http.Server{
+		Handler: websockCompatibleHandlerFunc(proxy, targetPort),
+	}
+
+	go func() {
+		server.Serve(listener)
+	}()
+
+	return &httpProxy{server}, nil
+}
+
+func (p *httpProxy) Close() error {
+	err := p.server.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type tcpPortProxy struct {
+	server *http.Server
+}
+
+func ProxyTCPPort(listener net.Listener, targetPort uint16) (ExposeProxy, error) {
+	server := &http.Server{
+		Handler: websocketToTCPHandlerFunc(targetPort),
+	}
+
+	go func() {
+		server.Serve(listener)
+	}()
+
+	return &tcpPortProxy{server}, nil
+}
+
+func (p *tcpPortProxy) Close() error {
+	err := p.server.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/expose/util/proxy_test.go
+++ b/expose/util/proxy_test.go
@@ -1,0 +1,390 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+)
+
+func listenOnRandomPort() (net.Listener, uint16, error) {
+	// allocate a port dynamically by specifying :0
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// retrive the selected port from the listener
+	_, portStr, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		return nil, 0, err
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return listener, uint16(port), nil
+}
+
+// Test that a simple HTTP GET request is proxied
+func TestBasicProxying(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, client")
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	_, portStr, _ := net.SplitHostPort(u.Host)
+	port, _ := strconv.Atoi(portStr)
+
+	listener, listenPort, err := listenOnRandomPort()
+	if err != nil {
+		t.Fatalf("listenOnRandomPort: %s", err)
+	}
+	defer listener.Close()
+
+	t.Logf("port %d proxying to port %d", listenPort, port)
+	ep, err := ProxyHTTP(listener, uint16(port))
+	if err != nil {
+		t.Fatalf("ProxyHTTP: %s", err)
+	}
+	defer ep.Close()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d", listenPort)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("http.Get: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %s", err)
+	}
+
+	assert.Equal(t, "Hello, client", string(body), "body is as expected")
+}
+
+// test that a streaming response is streamed, and not buffered completely before being
+// forwarded
+func TestStreamingProxy(t *testing.T) {
+	// the HTTP client will feed items into this channel one at a time, expecting the HTTP
+	// server to send them back through the body
+	bodyParts := make(chan []byte, 10)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+
+		flusher := w.(http.Flusher)
+		flusher.Flush()
+
+		for part := range bodyParts {
+			w.Write(part)
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	_, portStr, _ := net.SplitHostPort(u.Host)
+	port, _ := strconv.Atoi(portStr)
+
+	listener, listenPort, err := listenOnRandomPort()
+	if err != nil {
+		t.Fatalf("listenOnRandomPort: %s", err)
+	}
+	defer listener.Close()
+
+	t.Logf("port %d proxying to port %d", listenPort, port)
+	ep, err := ProxyHTTP(listener, uint16(port))
+	if err != nil {
+		t.Fatalf("ProxyHTTP: %s", err)
+	}
+	defer ep.Close()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d", listenPort)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %s", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http.Get: %s", err)
+	}
+	defer resp.Body.Close()
+
+	parts := [][]byte{[]byte("Hello"), []byte("Cruel"), []byte("World")}
+	buf := make([]byte, 1024)
+	for _, part := range parts {
+		// send the part to the http server
+		bodyParts <- part
+
+		// ..and read it back over the HTTP connection
+		n, err := resp.Body.Read(buf)
+		got := buf[:n]
+		if err != nil {
+			t.Fatalf("read body: %s", err)
+		}
+		assert.Equal(t, part, got, "expected body part")
+	}
+	close(bodyParts)
+
+	_, err = resp.Body.Read(buf)
+	assert.Equal(t, io.EOF, err, "expected EOF")
+}
+
+// Test that a websocket connection is properly proxied via ProxyHTTP
+func TestProxyHTTPWebsocket(t *testing.T) {
+	// a websocket server that reads a message, echoes it back, and closes
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{
+			Subprotocols: websocket.Subprotocols(r),
+			CheckOrigin: func(r *http.Request) bool {
+				return true
+			},
+		}
+
+		wsconn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Could not upgrade: %s", err), 500)
+			return
+		}
+		defer wsconn.Close()
+
+		messageType, payload, err := wsconn.ReadMessage()
+		if err != nil {
+			t.Logf("server ReadMessage: %s", err)
+			return
+		}
+
+		err = wsconn.WriteMessage(messageType, payload)
+		if err != nil {
+			t.Logf("server WriteMessage: %s", err)
+			return
+		}
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	_, portStr, _ := net.SplitHostPort(u.Host)
+	port, _ := strconv.Atoi(portStr)
+
+	listener, listenPort, err := listenOnRandomPort()
+	if err != nil {
+		t.Fatalf("listenOnRandomPort: %s", err)
+	}
+	defer listener.Close()
+
+	t.Logf("port %d proxying to port %d", listenPort, port)
+	ep, err := ProxyHTTP(listener, uint16(port))
+	if err != nil {
+		t.Fatalf("ProxyHTTP: %s", err)
+	}
+	defer ep.Close()
+
+	url := fmt.Sprintf("ws://127.0.0.1:%d", listenPort)
+	dialer := websocket.Dialer{}
+	ws, _, err := dialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("client Dial: %s", err)
+	}
+	defer ws.Close()
+
+	err = ws.WriteMessage(websocket.BinaryMessage, []byte("ECHO"))
+	if err != nil {
+		t.Fatalf("client WriteMessage: %s", err)
+	}
+
+	messageType, payload, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("client ReadMessage: %s", err)
+	}
+	assert.Equal(t, messageType, websocket.BinaryMessage, "expected message type")
+	assert.Equal(t, payload, []byte("ECHO"), "expected payload")
+
+	_, _, err = ws.ReadMessage()
+	if err == nil {
+		t.Fatalf("client ReadMessage 2: expected error")
+	}
+	if !websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
+		t.Fatalf("ReadMessage 2: %s", err)
+	}
+}
+
+// Test that ProxyTCPPort's HTTP server rejects non-websocket
+// connections
+func TestProxyTCPPortNotWebsocket(t *testing.T) {
+	listener, listenPort, err := listenOnRandomPort()
+	if err != nil {
+		t.Fatalf("listenOnRandomPort: %s", err)
+	}
+
+	ep, err := ProxyTCPPort(listener, 9999)
+	if err != nil {
+		t.Fatalf("ProxyTCPPort: %s", err)
+	}
+	defer ep.Close()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d", listenPort)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("http.Get: %s", err)
+	}
+	defer resp.Body.Close()
+
+	assert.Equal(t, 404, resp.StatusCode, "GET request should 404")
+}
+
+// Test that ProxyTCPPort's HTTP server rejects connections
+// to other than the root path (/)
+func TestProxyTCPPortNotRootPath(t *testing.T) {
+	listener, listenPort, err := listenOnRandomPort()
+	if err != nil {
+		t.Fatalf("listenOnRandomPort: %s", err)
+	}
+
+	ep, err := ProxyTCPPort(listener, 9999)
+	if err != nil {
+		t.Fatalf("ProxyTCPPort: %s", err)
+	}
+	defer ep.Close()
+
+	url := fmt.Sprintf("ws://127.0.0.1:%d/random/path", listenPort)
+	dialer := websocket.Dialer{}
+	_, _, err = dialer.Dial(url, nil)
+	assert.Equal(t, fmt.Errorf("websocket: bad handshake"), err, "should get bad handshake")
+}
+
+// Test that proxying a TCP port via websocket works correctly, by proxying
+// an echo server and testing that a message travels through a websocket
+// and back.  Test that the TCP connection is closed when the websocket closes.
+func TestProxyTCPPort(t *testing.T) {
+	// set up a TCP echo server on a random port
+	tcpListener, tcpListenerPort, err := listenOnRandomPort()
+	if err != nil {
+		t.Fatalf("listenOnRandomPort: %s", err)
+	}
+	defer tcpListener.Close()
+
+	// run a tcp echo server on that listener, that will send to
+	// connClosed once the connection is closed
+	connClosed := make(chan bool, 0)
+	go func() {
+		stream, err := tcpListener.Accept()
+		if err != nil {
+			t.Logf("err accepting: %s", err)
+			return
+		}
+
+		io.Copy(stream, stream)
+		_ = stream.Close()
+		connClosed <- true
+	}()
+
+	// set up a WS proxy to that port
+	listener, listenPort, err := listenOnRandomPort()
+	if err != nil {
+		t.Fatalf("listenOnRandomPort: %s", err)
+	}
+
+	t.Logf("port %d proxying to port %d", listenPort, tcpListenerPort)
+	ep, err := ProxyTCPPort(listener, tcpListenerPort)
+	if err != nil {
+		t.Fatalf("ProxyTCPPort: %s", err)
+	}
+	defer ep.Close()
+
+	// connect to that ws proxy
+	url := fmt.Sprintf("ws://127.0.0.1:%d/", listenPort)
+	dialer := websocket.Dialer{}
+	ws, _, err := dialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("Dial: %s", err)
+	}
+
+	err = ws.WriteMessage(websocket.BinaryMessage, []byte("Hello"))
+	if err != nil {
+		t.Fatalf("WriteMessage: %s", err)
+	}
+
+	messageType, payload, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage: %s", err)
+	}
+
+	assert.Equal(t, websocket.BinaryMessage, messageType, "got expected message type back")
+	assert.Equal(t, []byte("Hello"), payload, "got expected message back")
+
+	// test closing from the websocket side
+	ws.Close()
+
+	<-connClosed
+}
+
+// Similarly, test that the websocket is closed when the TCP connection closes.
+func TestProxyTCPPortTCPClose(t *testing.T) {
+	// set up a TCP echo server on a random port
+	tcpListener, tcpListenerPort, err := listenOnRandomPort()
+	if err != nil {
+		t.Fatalf("listenOnRandomPort: %s", err)
+	}
+	defer tcpListener.Close()
+
+	// on connection, simply write out GOODBYE and close
+	go func() {
+		stream, err := tcpListener.Accept()
+		if err != nil {
+			t.Logf("err accepting: %s", err)
+			return
+		}
+
+		stream.Write([]byte("GOODBYE"))
+		stream.Close()
+	}()
+
+	// set up a WS proxy to that port
+	listener, listenPort, err := listenOnRandomPort()
+	if err != nil {
+		t.Fatalf("listenOnRandomPort: %s", err)
+	}
+
+	ep, err := ProxyTCPPort(listener, tcpListenerPort)
+	if err != nil {
+		t.Fatalf("ProxyTCPPort: %s", err)
+	}
+	defer ep.Close()
+
+	// connect to that ws proxy
+	url := fmt.Sprintf("ws://127.0.0.1:%d/", listenPort)
+	dialer := websocket.Dialer{}
+	ws, _, err := dialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("Dial: %s", err)
+	}
+
+	messageType, payload, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage: %s", err)
+	}
+
+	assert.Equal(t, websocket.BinaryMessage, messageType, "got expected message type back")
+	assert.Equal(t, []byte("GOODBYE"), payload, "got expected message back")
+
+	_, _, err = ws.ReadMessage()
+	if err == nil {
+		t.Fatalf("ReadMessage 2: expected error")
+	}
+	if !websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
+		t.Fatalf("ReadMessage 2: %s", err)
+	}
+}

--- a/expose/util/ws2tcp.go
+++ b/expose/util/ws2tcp.go
@@ -1,0 +1,139 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var keepAliveInterval time.Duration
+
+// Accept websocket connections at path / and forward them to the local port.
+func websocketToTCPHandlerFunc(targetPort uint16) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+
+		if !websocket.IsWebSocketUpgrade(r) {
+			http.NotFound(w, r)
+			return
+		}
+
+		upgrader := websocket.Upgrader{
+			Subprotocols: websocket.Subprotocols(r),
+			CheckOrigin: func(r *http.Request) bool {
+				return true
+			},
+		}
+
+		wsconn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Could not upgrade: %s", err), 500)
+			return
+		}
+		defer wsconn.Close()
+
+		// only one thing is allowed to write to the wsconn at a time
+		var writeLock sync.Mutex
+
+		tcpconn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", targetPort))
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Could not connect to TCP port: %s", err), 502)
+			return
+		}
+		defer tcpconn.Close()
+
+		// when it's time to tear down the connection, tear down both sides
+		kill := func() {
+			tcpconn.Close()
+			wsconn.Close()
+		}
+
+		// Handle control messages
+		wsconn.SetPingHandler(func(appData string) error {
+			writeLock.Lock()
+			defer writeLock.Unlock()
+			return wsconn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(5*time.Second))
+		})
+
+		// send keepalives every 10s
+		ticker := time.NewTicker(10 * time.Second)
+		go func() {
+			for {
+				<-ticker.C
+
+				writeLock.Lock()
+				err := wsconn.WriteControl(websocket.PingMessage, nil, time.Now().Add(5*time.Second))
+				writeLock.Unlock()
+				if err != nil {
+					kill()
+					return
+				}
+			}
+		}()
+		defer ticker.Stop()
+
+		wsconn.SetCloseHandler(func(code int, text string) error {
+			kill()
+			return nil
+		})
+
+		// bridge the two connections together, breaking the connection entirely
+		// when any piece fails and completing this function when both directions
+		// are closed
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer kill()
+			for {
+				messageType, payload, err := wsconn.ReadMessage()
+				if err != nil {
+					// typically this means the connection was closed, but
+					// regardless of the error we want to close the TCP connection.
+					return
+				}
+				if messageType != websocket.BinaryMessage {
+					// this is a protocol error; we don't support Text
+					return
+				}
+
+				_, err = tcpconn.Write(payload)
+				if err != nil {
+					// An error occurred before the full payload could
+					// be written; close the connection
+					return
+				}
+			}
+		}()
+
+		go func() {
+			defer kill()
+			var buf []byte = make([]byte, 1024*512)
+			for {
+				n, err := tcpconn.Read(buf)
+				if err != nil {
+					return
+				}
+				var data = buf[:n]
+
+				writeLock.Lock()
+				err = wsconn.WriteMessage(websocket.BinaryMessage, data)
+				writeLock.Unlock()
+				if err != nil {
+					return
+				}
+			}
+		}()
+
+		wg.Wait()
+
+		return
+	}
+}

--- a/expose/util/wsproxy.go
+++ b/expose/util/wsproxy.go
@@ -1,0 +1,206 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// httputil.ReverseProxy in Go1.10 doesn't support websockets, so we intercept
+// that particular situation and do so manually.  This can all be removed once
+// generic-worker is upgraded to Go1.12 or higher.
+
+// What follows is based on websocktunnel's wsmux/wsmux.go
+type proxy struct {
+	targetPort uint16
+}
+
+var debug = false
+
+func (p *proxy) logf(format string, v ...interface{}) {
+	if debug {
+		fmt.Printf(format+"\n", v...)
+	}
+}
+
+func (p *proxy) logerrorf(format string, v ...interface{}) {
+	if debug {
+		fmt.Errorf(format+"\n", v...)
+	}
+}
+
+func (p *proxy) websocketProxy(w http.ResponseWriter, r *http.Request) error {
+	// at this point, we are sure that r is a http websocket upgrade request
+	p.logf("creating WS bridge: path=%s", r.URL.RequestURI())
+	dialer := &websocket.Dialer{
+		Subprotocols: websocket.Subprotocols(r),
+	}
+
+	// create new header
+	// copy request headers to new header. Avoid websocket headers
+	// as these will be added by Dial
+	reqHeader := make(http.Header)
+	for k, v := range r.Header {
+		if k == "Upgrade" ||
+			k == "Connection" ||
+			k == "Sec-Websocket-Key" ||
+			k == "Sec-Websocket-Version" ||
+			k == "Sec-Websocket-Extensions" ||
+			k == "Sec-Websocket-Protocol" {
+			continue
+		}
+		reqHeader[k] = v
+	}
+
+	uri := fmt.Sprintf("ws://127.0.0.1:%d", p.targetPort)
+	p.logf("dialing ws at: %s", uri)
+	tunnelConn, _, err := dialer.Dial(uri, reqHeader)
+	if err != nil {
+		p.logerrorf("could not dial tunnel: path=%s, error: %v", r.URL.RequestURI(), err)
+		return err
+	}
+
+	upgrader := websocket.Upgrader{
+		Subprotocols: websocket.Subprotocols(r),
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
+	}
+	viewerConn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		p.logerrorf("could not upgrade client connection: path=%s, error: %v", r.URL.RequestURI(), err)
+		// close tunnel connection
+		_ = tunnelConn.Close()
+		return err
+	}
+	p.logf("initiating connection bridge")
+
+	// bridge both websocket connections
+	bridgeErr := p.bridgeConn(tunnelConn, viewerConn)
+	if bridgeErr != nil {
+		p.logerrorf("bridge closed with err: %v", bridgeErr)
+	}
+
+	if bridgeErr != nil {
+		return bridgeErr
+	}
+	return err
+}
+
+func (p *proxy) bridgeConn(conn1 *websocket.Conn, conn2 *websocket.Conn) error {
+	// set ping and pong handlers
+	conn1.SetPingHandler(forwardControl(websocket.PingMessage, conn2))
+	conn2.SetPingHandler(forwardControl(websocket.PingMessage, conn1))
+
+	conn1.SetPongHandler(forwardControl(websocket.PongMessage, conn2))
+	conn2.SetPongHandler(forwardControl(websocket.PongMessage, conn1))
+
+	// set close handlers
+	conn1.SetCloseHandler(func(code int, text string) error {
+		return nil
+	})
+	conn2.SetCloseHandler(func(code int, text string) error {
+		return nil
+	})
+
+	// ensure connections are closed after bridge exits
+	defer func() {
+		_ = conn1.Close()
+		_ = conn2.Close()
+	}()
+
+	kill := make(chan bool, 1)
+	var eSrc, eDest atomic.Value
+	// Wait until errors are written
+
+	go func() {
+		err := copyWsData(conn1, conn2, kill)
+		if err != nil {
+			eSrc.Store(err)
+		}
+	}()
+	go func() {
+		err := copyWsData(conn2, conn1, kill)
+		if err != nil {
+			eDest.Store(err)
+		}
+	}()
+
+	<-kill
+	if err, ok := eSrc.Load().(error); ok && err != nil {
+		return err
+	}
+	if err, ok := eDest.Load().(error); ok && err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyWsData(dest *websocket.Conn, src *websocket.Conn, kill chan bool) error {
+	defer asyncClose(kill)
+	for {
+		mtype, reader, err := src.NextReader()
+		if err != nil {
+			// Abnormal closure occurs if the websocket is over a wsmux stream
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure,
+				websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				return err
+			}
+			return nil
+		}
+		writer, err := dest.NextWriter(mtype)
+		if err != nil {
+			// Abnormal closure occurs if the websocket is over a wsmux stream
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure,
+				websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				return err
+			}
+			return nil
+		}
+		_, err = io.Copy(writer, reader)
+		_ = writer.Close()
+		if err != nil {
+			return err
+		}
+
+		select {
+		case <-kill:
+			return nil
+		default:
+		}
+	}
+}
+
+func forwardControl(messageType int, dest *websocket.Conn) func(string) error {
+	return func(appData string) error {
+		return dest.WriteControl(messageType, []byte(appData), time.Now().Add(20*time.Second))
+	}
+}
+
+func asyncClose(kill chan bool) {
+	select {
+	case <-kill:
+	default:
+		close(kill)
+	}
+}
+
+// the main entry point: generate an http.HandlerFunc that will mostly just use
+// the given ReverseProxy, but will handle websockets, too.
+func websockCompatibleHandlerFunc(reverseproxy *httputil.ReverseProxy, targetPort uint16) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if websocket.IsWebSocketUpgrade(r) {
+			p := proxy{targetPort: targetPort}
+			_ = p.websocketProxy(w, r)
+		}
+
+		// not a websocket thing; defer to ReverseProxy
+		reverseproxy.ServeHTTP(w, r)
+		return
+	}
+}


### PR DESCRIPTION
This introduces a new package designed to expose services available on
the worker's loopback interface to the public Internet.  The services
can include both HTTP services, which are proxied directly, and TCP
services, which are made available via binary messages on a websocket.