### PR TITLE
Bug 1532588 - use reflect.DeepEqual rather than fmt.Sprintf("%q") for testing equality

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -109,7 +109,7 @@ func (errArtifact *ErrorArtifact) ResponseObject() interface{} {
 }
 
 func (errArtifact *ErrorArtifact) String() string {
-	return fmt.Sprintf("%q", *errArtifact)
+	return fmt.Sprintf("%v", *errArtifact)
 }
 
 // createTempFileForPUTBody gzip-compresses the file at path rawContentFile and writes

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -48,8 +47,7 @@ func validateArtifacts(
 	}
 	artifacts := tr.PayloadArtifacts()
 
-	// compare expected vs actual artifacts by converting artifacts to strings...
-	if fmt.Sprintf("%q", artifacts) != fmt.Sprintf("%q", expected) {
+	if !reflect.DeepEqual(artifacts, expected) {
 		t.Fatalf("Expected different artifacts to be generated...\nExpected:\n%q\nActual:\n%q", expected, artifacts)
 	}
 }


### PR DESCRIPTION
See [bug 1532588](https://bugzil.la/1532588) for details.