### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -259,7 +259,7 @@ func (s3Artifact *S3Artifact) String() string {
 	return fmt.Sprintf("S3 Artifact - Name: '%v', Path: '%v', Expires: %v, Content Encoding: '%v', MIME Type: '%v'", s3Artifact.Name, s3Artifact.Path, s3Artifact.Expires, s3Artifact.ContentEncoding, s3Artifact.ContentType)
 }
 
-// Returns the artifacts as listed in the payload of the task (note this does
+// PayloadArtifacts returns the artifacts as listed in the payload of the task (note this does
 // not include log files)
 func (task *TaskRun) PayloadArtifacts() []TaskArtifact {
 	artifacts := make([]TaskArtifact, 0)

--- a/fileutil/fileutil_all-unix-style.go
+++ b/fileutil/fileutil_all-unix-style.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-// Take ownership of files, and then give them 0600 file permissions
+// SecureFiles takes ownership of files, and then give them 0600 file permissions
 func SecureFiles(filepaths []string) (err error) {
 	var currentUser *user.User
 	currentUser, err = user.Current()

--- a/gwconfig/config.go
+++ b/gwconfig/config.go
@@ -81,7 +81,7 @@ type (
 	}
 )
 
-// writes config to json file
+// Persist writes config to json file
 func (c *Config) Persist(file string) error {
 	log.Print("Creating file " + file + "...")
 	return fileutil.WriteToFileAsJSON(c, file)

--- a/main.go
+++ b/main.go
@@ -1119,7 +1119,7 @@ func (e *ExecutionErrors) Error() string {
 	return strings.Join(lines, "\n")
 }
 
-// Return true if any of the accumlated errors is a worker-shutdown
+// WorkerShutdown returns true if any of the accumlated errors is a worker-shutdown
 func (e *ExecutionErrors) WorkerShutdown() bool {
 	if !e.Occurred() {
 		return false

--- a/mounts.go
+++ b/mounts.go
@@ -226,7 +226,7 @@ func (feature *MountsFeature) IsEnabled(task *TaskRun) bool {
 	return true
 }
 
-// Reads payload and initialises state...
+// NewTaskFeature reads payload and initialises state...
 func (feature *MountsFeature) NewTaskFeature(task *TaskRun) TaskFeature {
 	tm := &TaskMount{
 		task:    task,
@@ -392,7 +392,7 @@ func (w *WritableDirectoryCache) RequiredScopes() []string {
 	return []string{"generic-worker:cache:" + w.CacheName}
 }
 
-// Returns either a *URLContent *ArtifactContent, *RawContent or *Base64Content
+// FSContent returns either a *URLContent *ArtifactContent, *RawContent or *Base64Content
 // that is listed in the given *WritableDirectoryCache
 func (w *WritableDirectoryCache) FSContent() (FSContent, error) {
 	// no content if an empty cache folder, e.g. object directory
@@ -408,7 +408,7 @@ func (r *ReadOnlyDirectory) RequiredScopes() []string {
 	return []string{}
 }
 
-// Returns either a *URLContent, *ArtifactContent, *RawContent or
+// FSContent returns either a *URLContent, *ArtifactContent, *RawContent or
 // *Base64Content that is listed in the given *ReadOnlyDirectory
 func (r *ReadOnlyDirectory) FSContent() (FSContent, error) {
 	return FSContentFrom(r.Content)
@@ -420,7 +420,7 @@ func (f *FileMount) RequiredScopes() []string {
 	return []string{}
 }
 
-// Returns either a *URLContent, *ArtifactContent, *RawContent or
+// FSContent returns either a *URLContent, *ArtifactContent, *RawContent or
 // *Base64Content that is listed in the given *FileMount
 func (f *FileMount) FSContent() (FSContent, error) {
 	return FSContentFrom(f.Content)
@@ -670,7 +670,7 @@ func extract(fsContent FSContent, format string, dir string, task *TaskRun) erro
 	return fmt.Errorf("Unsupported archive format %v", format)
 }
 
-// Returns either a *ArtifactContent or *URLContent or *RawContent or *Base64Content based on the content
+// FSContentFrom returns either a *ArtifactContent or *URLContent or *RawContent or *Base64Content based on the content
 // (json.RawMessage)
 func FSContentFrom(c json.RawMessage) (FSContent, error) {
 	// c must be one of:

--- a/process/process_all-unix-style.go
+++ b/process/process_all-unix-style.go
@@ -90,7 +90,7 @@ func NewCommand(commandLine []string, workingDirectory string, env []string) (*C
 	}, nil
 }
 
-// Returns the exit code, or
+// ExitCode returns the exit code, or
 //  -1 if the process has not exited
 //  -2 if the process crashed
 //  -3 it could not be established what happened

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -88,7 +88,7 @@ func NewCommand(commandLine []string, workingDirectory string, env []string, acc
 	}, nil
 }
 
-// Returns the exit code, or
+// ExitCode returns the exit code, or
 //  -1 if the process has not exited
 //  -2 if the process crashed
 //  -3 it could not be established what happened

--- a/win32/win32acl_windows.go
+++ b/win32/win32acl_windows.go
@@ -110,7 +110,7 @@ func AddAceToWindowStation(winsta Hwinsta, sid *syscall.SID) error {
 	return SetAclTo(syscall.Handle(winsta), acl)
 }
 
-// Return byte slice of given size, aligned at given offset.
+// AlignedBuffer returns byte slice of given size, aligned at given offset.
 func AlignedBuffer(size, offset int) []byte {
 	buf := make([]byte, size+offset)
 	ofs := int((uintptr(offset) - uintptr(unsafe.Pointer(&buf[0]))%uintptr(offset)) % uintptr(offset))

--- a/yamltojson/main.go
+++ b/yamltojson/main.go
@@ -26,7 +26,7 @@ func main() {
 	fmt.Println(string(formatted))
 }
 
-// Takes json []byte input, unmarshals and then marshals, in order to get a
+// FormatJSON takes json []byte input, unmarshals and then marshals, in order to get a
 // canonical representation of json (i.e. formatted with objects ordered).
 // Ugly and perhaps inefficient, but effective! :p
 func FormatJSON(a []byte) ([]byte, error) {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?