### PR TITLE
Bug 1533694 - fix to run runAfterUserCreation code in current task directory

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -203,6 +203,7 @@ func TestRemoveTaskDirs(t *testing.T) {
 		},
 	}
 	taskContext = &TaskContext{
+		TaskDir: filepath.Join(d, "task_1234561234"),
 		User: &runtime.OSUser{
 			Name: "task_1234561234",
 		},
@@ -237,9 +238,16 @@ func TestRemoveTaskDirs(t *testing.T) {
 		"applesnpears":   true,
 	}
 	if len(fi) != len(expectedDirs)+len(expectedFiles) {
+		t.Logf("Found:")
 		for _, file := range fi {
-			t.Logf("File %v", file.Name())
+			if file.IsDir() {
+				t.Logf("  Directory %v", file.Name())
+			} else {
+				t.Logf("  File %v", file.Name())
+			}
 		}
+		t.Logf("Expected files: %v", expectedFiles)
+		t.Logf("Expected directories: %v", expectedDirs)
 		t.Fatalf("Expected to find %v directory records (%v dirs + %v files) but found %v", len(expectedDirs)+len(expectedFiles), len(expectedDirs), len(expectedFiles), len(fi))
 	}
 	for _, file := range fi {


### PR DESCRIPTION
See [bug 1533694 comment 4](https://bugzilla.mozilla.org/show_bug.cgi?id=1533694#c4) for context.

In `generic-worker 14.0.1` the code executed from the `runAfterUserCreation` config setting was run not in the task directory of the current task user, but in the task directory that has been prepared for the subsequent task user. This fixes this bug and simplifies the code paths a little.