### PR TITLE
Bug 1543082 - only log to task logs if task is running

### DIFF
--- a/mounts.go
+++ b/mounts.go
@@ -84,7 +84,9 @@ func (cache *Cache) Rating() float64 {
 }
 
 func (cache *Cache) Expunge(task *TaskRun) error {
-	task.Infof("[mounts] Removing cache %v from cache table", cache.Key)
+	if task != nil {
+		task.Infof("[mounts] Removing cache %v from cache table", cache.Key)
+	}
 	delete(cache.Owner, cache.Key)
 	if task != nil {
 		task.Infof("[mounts] Deleting cache %v file(s) at %v", cache.Key, cache.Location)


### PR DESCRIPTION
See [bug 1543082](https://bugzil.la/1543082) for more context.

See [sentry issue GENERIC-WORKER-1J](https://sentry.prod.mozaws.net/operations/generic-worker/issues/5508600/).