### PR TITLE
Bug 1436195 - fix livelog certs, port

### DIFF
--- a/expose/statelessdns_test.go
+++ b/expose/statelessdns_test.go
@@ -23,9 +23,10 @@ import (
 var hostDomain = "stateless-dns.example.com"
 var secret = "sshhh!"
 
-func makeStatlessDNSExposer(t *testing.T) Exposer {
+func makeStatelessDNSExposer(t *testing.T) Exposer {
 	exposer, err := NewStatelessDNS(
 		net.ParseIP("127.0.0.1"),
+		0,
 		hostDomain,
 		secret,
 		time.Minute,
@@ -49,7 +50,7 @@ func TestStatelessDNSExposeHTTP(t *testing.T) {
 	_, testPortStr, _ := net.SplitHostPort(testURL.Host)
 	testPort, _ := strconv.Atoi(testPortStr)
 
-	exposer := makeStatlessDNSExposer(t)
+	exposer := makeStatelessDNSExposer(t)
 	exposure, err := exposer.ExposeHTTP(uint16(testPort))
 	if err != nil {
 		t.Fatalf("ExposeHTTP returned an error: %v", err)
@@ -117,7 +118,7 @@ func TestStatelessDNSExposePort(t *testing.T) {
 		_ = stream.Close()
 	}()
 
-	exposer := makeStatlessDNSExposer(t)
+	exposer := makeStatelessDNSExposer(t)
 	exposure, err := exposer.ExposeTCPPort(uint16(tcpListenerPort))
 	if err != nil {
 		t.Fatalf("ExposeTCPPort returned an error: %v", err)

--- a/livelog.go
+++ b/livelog.go
@@ -16,7 +16,8 @@ import (
 )
 
 var (
-	livelogName = "public/logs/live.log"
+	livelogName            = "public/logs/live.log"
+	internalGETPort uint16 = 60099
 )
 
 type LiveLogFeature struct {
@@ -64,7 +65,7 @@ func (l *LiveLogTask) RequiredScopes() scopes.Required {
 }
 
 func (l *LiveLogTask) Start() *CommandExecutionError {
-	liveLog, err := livelog.New(config.LiveLogExecutable, config.LiveLogPUTPort, config.LiveLogGETPort)
+	liveLog, err := livelog.New(config.LiveLogExecutable, config.LiveLogPUTPort, internalGETPort)
 	if err != nil {
 		log.Printf("WARNING: could not create livelog: %s", err)
 		// then run without livelog, is only a "best effort" service
@@ -159,7 +160,7 @@ func (l *LiveLogTask) reinstateBackingLog() {
 
 func (l *LiveLogTask) uploadLiveLogArtifact() error {
 	var err error
-	l.exposure, err = exposer.ExposeHTTP(config.LiveLogGETPort)
+	l.exposure, err = exposer.ExposeHTTP(internalGETPort)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -338,7 +338,18 @@ func setupExposer() (err error) {
 			config.WorkerGroup,
 			config.WorkerID,
 			config.Auth())
-	} else if config.LiveLogSecret != "" {
+	} else if config.LiveLogSecret != "" && config.LiveLogCertificate != "" && config.LiveLogKey != "" {
+		var cert, key []byte
+		cert, err = ioutil.ReadFile(config.LiveLogCertificate)
+		if err != nil {
+			return
+		}
+
+		key, err = ioutil.ReadFile(config.LiveLogKey)
+		if err != nil {
+			return
+		}
+
 		exposer, err = expose.NewStatelessDNS(
 			config.PublicIP,
 			config.Subdomain,
@@ -347,8 +358,8 @@ func setupExposer() (err error) {
 			// will no longer work anyway (because the port number is dynamic), so this extra validity
 			// does not hurt anything.
 			24*time.Hour,
-			config.LiveLogCertificate,
-			config.LiveLogKey)
+			string(cert),
+			string(key))
 	} else {
 		exposer, err = expose.NewLocal(config.PublicIP)
 	}

--- a/main.go
+++ b/main.go
@@ -352,6 +352,7 @@ func setupExposer() (err error) {
 
 		exposer, err = expose.NewStatelessDNS(
 			config.PublicIP,
+			config.LiveLogGETPort,
 			config.Subdomain,
 			config.LiveLogSecret,
 			// Allow each exposure to last for 24 hours. After the task completes, the exposure URL


### PR DESCRIPTION
The first fixes a silly bug: I was passing filenames where PEM data was expected.

The second is a little more significant: without this change, exposer serves exposed things on an arbitrary port, but of course we don't have arbitrary ports open.  We have a single port open, which is labeled "livelogGETPort" in the configuration.  So, we configure the stateless DNS exposer to always expose on that port.  The similarly-named "livelogPUTPort" is not really similar -- it's used for communication between the task execution and the livelog process.  That's really an implementation detail and should probably be moved out of the config eventually.  And, once stateless DNS is turned off, we can get rid of `livelogCertificate`, `livelogGETPort`, `livelogKey`, and `livelogSecret`.

This ran a task with logs served over stateless DNS.  See it in action at https://tools.taskcluster.net/groups/aYhpWoTPSAWm47yk_VW2vg/tasks/aYhpWoTPSAWm47yk_VW2vg (or more accurately, by creating a new task like that one).