### PR TITLE
README.md: mention build.sh in building from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ If you prefer not to use a prepackaged binary, or want to have the latest unrele
 * Run `go get github.com/taskcluster/livelog`
 * Run `go get github.com/taskcluster/taskcluster-proxy`
 
+Note that the build process requires custom tooling, and your `go get` may mention errors.
+
+Run `./build.sh` to build binaries, ensure dependencies are vendored, and generate code.
+
+`./build.sh` takes optional arguments, `-a` to build all platforms, and `-t` to run tests. By default tests are not run and only the current platform is built.
+
 All being well, the binaries will be built under `${GOPATH}/bin`.
 
 # Acquire taskcluster credentials for running tests

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you prefer not to use a prepackaged binary, or want to have the latest unrele
 * Run `go get github.com/taskcluster/livelog`
 * Run `go get github.com/taskcluster/taskcluster-proxy`
 
-Note that the build process requires custom tooling, and your `go get` may mention errors.
+Run `go get -tags nativeEngine github.com/taskcluster/generic-worker` (all platforms) and/or `go get -tags dockerEngine github.com/taskcluster/generic-worker` (linux only). This should also build binaries for your platform.
 
 Run `./build.sh` to check go version, generate code, build binaries, compile (but not run) tests, perform linting, and ensure there are no ineffective assignments in go code.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you prefer not to use a prepackaged binary, or want to have the latest unrele
 
 Note that the build process requires custom tooling, and your `go get` may mention errors.
 
-Run `./build.sh` to build binaries, ensure dependencies are vendored, and generate code.
+Run `./build.sh` to check go version, generate code, build binaries, compile (but not run) tests, perform linting, and ensure there are no ineffective assignments in go code.
 
 `./build.sh` takes optional arguments, `-a` to build all platforms, and `-t` to run tests. By default tests are not run and only the current platform is built.
 


### PR DESCRIPTION
it wasn't immediately clear to me why `go get github.com/taskcluster/generic-worker` resulted in errors, this should clear some of that up