### PR TITLE
Bug 1551164 - move create/purge task directory steps into task-claim-and-execute loop

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -115,6 +115,11 @@ tasks:
       - generic-worker:cache:generic-worker-checkout
     payload:
       maxRunTime: 3600
+      env:
+        # Python 2 is needed for TestDesktopResizeAndMovePointer
+        # Powershell is needed for TestMounts
+        # System32 is needed for e.g. cmd.exe, icacls.exe, ...
+        PATH: C:\Windows\System32;C:\Windows\System32\WindowsPowerShell\v1.0;C:\mozilla-build\python
       command:
         - set CGO_ENABLED=0
         - set GOPATH=%CD%\gopath1.10.8

--- a/main.go
+++ b/main.go
@@ -430,11 +430,6 @@ func RunWorker() (exitCode ExitCode) {
 		return INTERNAL_ERROR
 	}
 
-	reboot := PrepareTaskEnvironment()
-	if reboot {
-		return REBOOT_REQUIRED
-	}
-
 	// number of tasks resolved since worker first ran
 	// stored in a json file, since we may reboot between tasks etc
 	tasksResolved := ReadTasksResolvedFile()
@@ -445,11 +440,7 @@ func RunWorker() (exitCode ExitCode) {
 			panic(err)
 		}
 	}(&tasksResolved)
-	err = purgeOldTasks()
-	// errors are not fatal
-	if err != nil {
-		log.Printf("WARNING: failed to remove old task directories/users: %v", err)
-	}
+
 	// Queue is the object we will use for accessing queue api
 	queue = config.Queue()
 	provisioner = config.AWSProvisioner()
@@ -474,6 +465,17 @@ func RunWorker() (exitCode ExitCode) {
 	sigInterrupt := make(chan os.Signal, 1)
 	signal.Notify(sigInterrupt, os.Interrupt)
 	for {
+
+		reboot := PrepareTaskEnvironment()
+		if reboot {
+			return REBOOT_REQUIRED
+		}
+
+		err = purgeOldTasks()
+		// errors are not fatal
+		if err != nil {
+			log.Printf("WARNING: failed to remove old task directories/users: %v", err)
+		}
 
 		// See https://bugzil.la/1298010 - routinely check if this worker type is
 		// outdated, and shut down if a new deployment is required.

--- a/mounts_broken_on_docker_test.go
+++ b/mounts_broken_on_docker_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -115,7 +116,12 @@ func TestMounts(t *testing.T) {
 	payload := GenericWorkerPayload{
 		Mounts: toMountArray(t, &mounts),
 		// since this checks that SHA values of files as the task user, is also ensures they are readable by task user
-		Command:    checkSHASums(),
+		Command: checkSHASums(),
+		// Don't assume powershell is in the default system PATH, but rather
+		// require that powershell is in the PATH of the test process.
+		Env: map[string]string{
+			"PATH": os.Getenv("PATH"),
+		},
 		MaxRunTime: 180,
 	}
 

--- a/plat_all-unix-style_test.go
+++ b/plat_all-unix-style_test.go
@@ -2,7 +2,13 @@
 
 package main
 
-import "testing"
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestSeparateTaskUsersNotSupported(t *testing.T) {
 	defer setup(t)()
@@ -10,5 +16,41 @@ func TestSeparateTaskUsersNotSupported(t *testing.T) {
 	exitCode := RunWorker()
 	if exitCode != INVALID_CONFIG {
 		t.Fatalf("Got exit code %v but was expecting exit code %v", exitCode, INVALID_CONFIG)
+	}
+}
+
+func TestNewTaskDirectoryForEachTask(t *testing.T) {
+	defer setup(t)()
+	config.NumberOfTasksToRun = 3
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(0),
+		MaxRunTime: 10,
+	}
+	td := testTask(t)
+	for i := uint(0); i < config.NumberOfTasksToRun; i++ {
+		_ = scheduleTask(t, td, payload)
+	}
+
+	execute(t, TASKS_COMPLETE)
+
+	// scan task directories, to make sure there are three unique backing log files,
+	// implying that each task ran in its own directory
+
+	var backingLogsFound uint = 0
+	err := filepath.Walk(config.TasksDir, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		if info.Name() != "live_backing.log" {
+			return fmt.Errorf("Discovered file %q but was expecting %q", info.Name(), "live_backing.log")
+		}
+		backingLogsFound++
+		return nil
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	if backingLogsFound != config.NumberOfTasksToRun {
+		log.Fatalf("Expected to find %v backing logs, but found %v", config.NumberOfTasksToRun, backingLogsFound)
 	}
 }

--- a/plat_windows_test.go
+++ b/plat_windows_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
@@ -101,6 +102,11 @@ func TestDesktopResizeAndMovePointer(t *testing.T) {
 	payload := GenericWorkerPayload{
 		Command:    commands,
 		MaxRunTime: 90,
+		// Don't assume python 2 is in the default system PATH, but rather
+		// require that python 2 is in the PATH of the test process.
+		Env: map[string]string{
+			"PATH": os.Getenv("PATH"),
+		},
 	}
 	td := testTask(t)
 


### PR DESCRIPTION
For workers that run more than one task per generic-worker invocation, the task directory creation and purging logic was broken with the code changes from [bug 1533694](https://bugzil.la/1533694), meaning that only a single task directory was created per generic-worker invocation, rather than between every task.

This impacted macOS and linux workers. The fix is to move the task directory creation and task directory purging into the main loop that claims and executes tasks.