### PR TITLE
Updates for new worker-manager interfaces

### DIFF
--- a/plat_all-unix-style.go
+++ b/plat_all-unix-style.go
@@ -33,7 +33,7 @@ func (pd *PlatformData) ReleaseResources() error {
 func immediateShutdown(cause string) {
 	log.Println("Immediate shutdown being issued...")
 	log.Println(cause)
-	cmd := exec.Command("shutdown", "now", cause)
+	cmd := exec.Command("sudo", "/sbin/shutdown", "now", cause)
 	err := cmd.Run()
 	if err != nil {
 		log.Fatal(err)
@@ -44,7 +44,7 @@ func immediateReboot() {
 	log.Println("Immediate reboot being issued...")
 	cause := "generic-worker requested reboot"
 	log.Println(cause)
-	cmd := exec.Command("shutdown", "/r", "now", cause)
+	cmd := exec.Command("sudo", "/sbin/shutdown", "-r", "now", cause)
 	err := cmd.Run()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Let's not land this quite yet. I push this to show what the interface worker-manager expects. The big TODO before landing (among whatever else you spot that I should change) is de-duping the parts of this that are the same as `--configure-for-aws`. How would you like me to go about organizing this?