### PR TITLE
Testing runAfterUserCreation runs as task user, not generic-worker process user

### DIFF
--- a/testdata/run-after-user.bat
+++ b/testdata/run-after-user.bat
@@ -1,1 +1,1 @@
-echo run-after-user > run-after-user.txt
+whoami > run-after-user.txt

--- a/user_creation_windows_test.go
+++ b/user_creation_windows_test.go
@@ -20,9 +20,9 @@ func TestRunAfterUserCreation(t *testing.T) {
 			t.Fatalf("Problem deleting old tasks: %v", err)
 		}
 	}()
-	fileContents, err := ioutil.ReadAll(filepath.Join(taskContext.TaskDir, "run-after-user.txt"))
+	fileContents, err := ioutil.ReadFile(filepath.Join(taskContext.TaskDir, "run-after-user.txt"))
 	if err != nil {
-		t.Fatalf("Got error when looking for file %v: %v", file, err)
+		t.Fatalf("Got error when looking for file run-after-user.txt: %v", err)
 	}
 	if !strings.Contains(string(fileContents), "task_") {
 		t.Fatalf("Expected runAfterUserCreation script to run as task user - but it ran as %v", string(fileContents))

--- a/user_creation_windows_test.go
+++ b/user_creation_windows_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"os"
+	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -19,9 +20,11 @@ func TestRunAfterUserCreation(t *testing.T) {
 			t.Fatalf("Problem deleting old tasks: %v", err)
 		}
 	}()
-	file := filepath.Join(taskContext.TaskDir, "run-after-user.txt")
-	_, err := os.Stat(file)
+	fileContents, err := ioutil.ReadAll(filepath.Join(taskContext.TaskDir, "run-after-user.txt"))
 	if err != nil {
 		t.Fatalf("Got error when looking for file %v: %v", file, err)
+	}
+	if !strings.Contains(string(fileContents), "task_") {
+		t.Fatalf("Expected runAfterUserCreation script to run as task user - but it ran as %v", string(fileContents))
 	}
 }


### PR DESCRIPTION
See [bug 1559157 comment 7](https://bugzilla.mozilla.org/show_bug.cgi?id=1559157#c7) for context.