### PR TITLE
Bug 1567073 - log all commands that are executed on the host

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,7 @@ if $TEST; then
   fi
 fi
 go get golang.org/x/lint/golint
-golint ./...
+golint $(go list ./...) | sed "s*${PWD}/**"
 go get github.com/gordonklaus/ineffassign
 ineffassign .
 

--- a/fileutil/fileutil_posix.go
+++ b/fileutil/fileutil_posix.go
@@ -5,9 +5,10 @@ package fileutil
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/taskcluster/generic-worker/host"
 )
 
 // SecureFiles makes the current user/group the owner of all files in
@@ -16,21 +17,21 @@ func SecureFiles(filepaths []string) (err error) {
 	// Use /usr/bin/id rather than user.Current due to https://bugzil.la/1566159
 	// Note, if we enabled CGO in builds, we could use user.Current, but for now
 	// we've decided not to.
-	uidBytes, err := exec.Command("/usr/bin/id", "-u").CombinedOutput()
+	uidString, err := host.CombinedOutput("/usr/bin/id", "-u")
 	if err != nil {
-		return fmt.Errorf("%s: %v", uidBytes, err)
+		return err
 	}
 	// Use /usr/bin/id rather than user.Current due to https://bugzil.la/1566159
-	gidBytes, err := exec.Command("/usr/bin/id", "-g").CombinedOutput()
+	gidString, err := host.CombinedOutput("/usr/bin/id", "-g")
 	if err != nil {
-		return fmt.Errorf("%s: %v", gidBytes, err)
+		return err
 	}
-	uidString := strings.TrimSpace(string(uidBytes))
+	uidString = strings.TrimSpace(uidString)
 	uid, err := strconv.Atoi(uidString)
 	if err != nil {
 		return fmt.Errorf("Could not convert %v to an integer uid: %v", uidString, err)
 	}
-	gidString := strings.TrimSpace(string(gidBytes))
+	gidString = strings.TrimSpace(gidString)
 	gid, err := strconv.Atoi(gidString)
 	if err != nil {
 		return fmt.Errorf("Could not convert %v to an integer gid: %v", gidString, err)

--- a/host/host.go
+++ b/host/host.go
@@ -1,0 +1,69 @@
+// Package host provides facilities for interfacing with the host operating
+// system, logging activities performed.
+package host
+
+import (
+	"log"
+	"os/exec"
+	"strings"
+
+	"github.com/taskcluster/shell"
+)
+
+// Run is equivalent to exec.Command(name, arg...).Run() but with logging.
+func Run(name string, arg ...string) (err error) {
+	_, err = RunCommand(exec.Command(name, arg...))
+	return
+}
+
+// CombinedOutput is equivalent to exec.Command(name, arg...).CombinedOutput()
+// but with logging.
+func CombinedOutput(name string, arg ...string) (combinedOutput string, err error) {
+	return RunCommand(exec.Command(name, arg...))
+}
+
+// RunBatch calls Run for each command in commands, in sequence. If allowFail
+// is false it will return if an error is returned from Run. All errors are
+// logged regardless of allowFail. The returned error is the result of the last
+// Run call.
+func RunBatch(allowFail bool, commands ...[]string) (err error) {
+	for _, command := range commands {
+		err = Run(command[0], command[1:]...)
+		if err != nil {
+			log.Printf("%v", err)
+			if !allowFail {
+				return err
+			}
+		}
+	}
+	return err
+}
+
+// RunIgnoreError calls CombinedOutput(comand, args...). If errString is found
+// in the command output, found is true and err is nil.  Otherwise found is
+// false, and err is the error returned from CombinedOutput (possibly nil).
+func RunIgnoreError(errString string, command string, args ...string) (found bool, err error) {
+	output, err := CombinedOutput(command, args...)
+	if err != nil {
+		if strings.Contains(output, errString) {
+			return true, nil
+		}
+	}
+	return false, err
+}
+
+// RunCommand logs cmd.Args, calls cmd.CombinedOutput(), and if an error
+// occurs, logs the command output. It does not log the error, it is expected
+// that the caller takes care of logging error, if required. The caller is not
+// expected to log the command output in the case of failure, since this
+// function has already done that. The combined output is cast to a string and
+// returned together with the error.
+func RunCommand(cmd *exec.Cmd) (combinedOutput string, err error) {
+	log.Print("Running command: " + shell.Escape(cmd.Args...))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Print("Error running command:")
+		log.Print(string(out))
+	}
+	return string(out), err
+}

--- a/host/host_posix.go
+++ b/host/host_posix.go
@@ -1,0 +1,21 @@
+// +build darwin linux
+
+package host
+
+import "log"
+
+func ImmediateReboot() {
+	log.Println("Immediate reboot being issued...")
+	err := Run("/usr/bin/sudo", "/sbin/shutdown", "-r", "now", "generic-worker requested reboot")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ImmediateShutdown(cause string) {
+	log.Println("Immediate shutdown being issued...")
+	err := Run("/usr/bin/sudo", "/sbin/shutdown", "-h", "now", cause)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -1,0 +1,19 @@
+package host
+
+import "log"
+
+func ImmediateReboot() {
+	log.Println("Immediate reboot being issued...")
+	err := Run("C:\\Windows\\System32\\shutdown.exe", "/r", "/t", "3", "/c", "generic-worker requested reboot")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ImmediateShutdown(cause string) {
+	log.Println("Immediate shutdown being issued...")
+	err := Run("C:\\Windows\\System32\\shutdown.exe", "/s", "/t", "3", "/c", cause)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	docopt "github.com/docopt/docopt-go"
 	"github.com/taskcluster/generic-worker/expose"
 	"github.com/taskcluster/generic-worker/gwconfig"
+	"github.com/taskcluster/generic-worker/host"
 	"github.com/taskcluster/generic-worker/process"
 	gwruntime "github.com/taskcluster/generic-worker/runtime"
 	"github.com/taskcluster/taskcluster-base-go/scopes"
@@ -154,18 +155,18 @@ func main() {
 		switch exitCode {
 		case REBOOT_REQUIRED:
 			if !config.DisableReboots {
-				immediateReboot()
+				host.ImmediateReboot()
 			}
 		case IDLE_TIMEOUT:
 			if config.ShutdownMachineOnIdle {
-				immediateShutdown("generic-worker idle timeout")
+				host.ImmediateShutdown("generic-worker idle timeout")
 			}
 		case INTERNAL_ERROR:
 			if config.ShutdownMachineOnInternalError {
-				immediateShutdown("generic-worker internal error")
+				host.ImmediateShutdown("generic-worker internal error")
 			}
 		case NONCURRENT_DEPLOYMENT_ID:
-			immediateShutdown("generic-worker deploymentId is not latest")
+			host.ImmediateShutdown("generic-worker deploymentId is not latest")
 		}
 		os.Exit(int(exitCode))
 	case arguments["install"]:

--- a/mounts_multiuser.go
+++ b/mounts_multiuser.go
@@ -20,9 +20,9 @@ func makeReadWritableForTaskUser(task *TaskRun, fileOrDirectory string, filetype
 	// However, if running as current user, taskContext.pd is not set, so use
 	// taskContext.User.Name instead of credentials inside taskContext.pd.
 	task.Infof("[mounts] Granting %v full control of %v '%v'", taskContext.User.Name, filetype, fileOrDirectory)
-	output, err := makeFileOrDirReadWritableForUser(recurse, fileOrDirectory, taskContext.User)
+	err := makeFileOrDirReadWritableForUser(recurse, fileOrDirectory, taskContext.User)
 	if err != nil {
-		return fmt.Errorf("[mounts] Not able to make %v %v writable for %v: %v: %v", filetype, fileOrDirectory, taskContext.User.Name, err, string(output))
+		return fmt.Errorf("[mounts] Not able to make %v %v writable for %v: %v", filetype, fileOrDirectory, taskContext.User.Name, err)
 	}
 	return nil
 }
@@ -31,9 +31,9 @@ func makeDirUnreadableForTaskUser(task *TaskRun, dir string) error {
 	// It doesn't concern us if config.RunTasksAsCurrentUser is set or not
 	// because files inside task directory should be owned/managed by task user
 	task.Infof("[mounts] Denying %v access to '%v'", taskContext.User.Name, dir)
-	output, err := makeDirUnreadableForUser(dir, taskContext.User)
+	err := makeDirUnreadableForUser(dir, taskContext.User)
 	if err != nil {
-		return fmt.Errorf("[mounts] Not able to make root-owned directory %v have permissions 0700 in order to make it unreadable for %v: %v: %v", dir, taskContext.User.Name, err, string(output))
+		return fmt.Errorf("[mounts] Not able to make root-owned directory %v have permissions 0700 in order to make it unreadable for %v: %v", dir, taskContext.User.Name, err)
 	}
 	return nil
 }

--- a/multiuser.go
+++ b/multiuser.go
@@ -79,8 +79,8 @@ func PlatformTaskEnvironmentSetup(taskDirName string) (reboot bool) {
 		// Make sure task user has full control of task directory. Due to
 		// https://bugzilla.mozilla.org/show_bug.cgi?id=1439588#c38 we can't
 		// assume previous MkdirAll has granted this permission.
-		output, err := makeFileOrDirReadWritableForUser(false, taskContext.TaskDir, taskContext.User)
-		log.Printf("Granting %v control of %v: %v", taskContext.User.Name, taskContext.TaskDir, string(output))
+		log.Printf("Granting %v control of %v", taskContext.User.Name, taskContext.TaskDir)
+		err = makeFileOrDirReadWritableForUser(false, taskContext.TaskDir, taskContext.User)
 		if err != nil {
 			panic(err)
 		}

--- a/process/docker.go
+++ b/process/docker.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/taskcluster/shell"
 	"golang.org/x/net/context"
 )
 
@@ -45,7 +46,7 @@ func (c *Command) DirectOutput(writer io.Writer) {
 }
 
 func (c *Command) String() string {
-	return fmt.Sprintf("%q", c.cmd)
+	return shell.Escape(c.cmd...)
 }
 
 func (c *Command) Execute() (r *Result) {

--- a/process/multiuser_posix.go
+++ b/process/multiuser_posix.go
@@ -32,24 +32,24 @@ func TaskUserPlatformData() (pd *PlatformData, err error) {
 		return nil, fmt.Errorf("Could not determine interactive username: %v", err)
 	}
 
-	id := func(idName string, idOpts string) (uint32, error) {
-		out, err := host.CombinedOutput("id", idOpts, user)
+	id := func(description string, command string, args ...string) (uint32, error) {
+		out, err := host.CombinedOutput(command, args...)
 		if err != nil {
-			return 0, fmt.Errorf("Failed to run `id` command to determine %v of user %v: %v", idName, user, err)
+			return 0, fmt.Errorf("Failed to run command to determine %v of user %v: %v", description, user, err)
 		}
 		idString := strings.TrimSpace(out)
 		id, err := strconv.Atoi(idString)
 		if err != nil {
-			return 0, fmt.Errorf("Failed to convert %v %q from a string to an int: %v", idName, idString, err)
+			return 0, fmt.Errorf("Failed to convert %v %q from a string to an int: %v", description, idString, err)
 		}
 		return uint32(id), nil
 	}
 
-	uid, err := id("UID", "-ur")
+	uid, err := id("UID", "id", "-ur", user)
 	if err != nil {
 		return nil, err
 	}
-	gid, err := id("GID", "-gr")
+	gid, err := id("GID", "id", "-gr", user)
 	if err != nil {
 		return nil, err
 	}

--- a/process/multiuser_posix.go
+++ b/process/multiuser_posix.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"syscall"
 
+	"github.com/taskcluster/generic-worker/host"
 	"github.com/taskcluster/generic-worker/runtime"
 )
 
@@ -27,21 +29,36 @@ func NewPlatformData(currentUser bool) (pd *PlatformData, err error) {
 func TaskUserPlatformData() (pd *PlatformData, err error) {
 	user, err := runtime.InteractiveUsername()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Could not determine interactive username: %v", err)
 	}
-	uid, err := strconv.Atoi(runtime.CommandOutputOrPanic(`id`, `-ur`, user))
+
+	id := func(idName string, idOpts string) (uint32, error) {
+		out, err := host.CombinedOutput("id", idOpts, user)
+		if err != nil {
+			return 0, fmt.Errorf("Failed to run `id` command to determine %v of user %v: %v", idName, user, err)
+		}
+		idString := strings.TrimSpace(out)
+		id, err := strconv.Atoi(idString)
+		if err != nil {
+			return 0, fmt.Errorf("Failed to convert %v %q from a string to an int: %v", idName, idString, err)
+		}
+		return uint32(id), nil
+	}
+
+	uid, err := id("UID", "-ur")
 	if err != nil {
 		return nil, err
 	}
-	gid, err := strconv.Atoi(runtime.CommandOutputOrPanic(`id`, `-gr`, user))
+	gid, err := id("GID", "-gr")
 	if err != nil {
 		return nil, err
 	}
+
 	return &PlatformData{
 		SysProcAttr: &syscall.SysProcAttr{
 			Credential: &syscall.Credential{
-				Uid: uint32(uid),
-				Gid: uint32(gid),
+				Uid: uid,
+				Gid: gid,
 			},
 		},
 	}, nil
@@ -118,16 +135,16 @@ func (c *Command) SetEnv(envVar, value string) {
 	c.Cmd.Env = append(c.Cmd.Env, envVar+"="+value)
 }
 
-func (c *Command) Kill() (killOutput []byte, err error) {
+func (c *Command) Kill() (killOutput string, err error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	if c.Process == nil {
 		// If process hasn't been started yet, nothing to kill
-		return []byte{}, nil
+		return "", nil
 	}
 	close(c.abort)
 	log.Printf("Killing process tree with parent PID %v... (%p)", c.Process.Pid, c)
 	defer log.Printf("Process tree with parent PID %v killed.", c.Process.Pid)
 	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
-	return []byte{}, syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+	return "", syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
 }

--- a/process/simple.go
+++ b/process/simple.go
@@ -76,16 +76,16 @@ func (c *Command) SetEnv(envVar, value string) {
 	c.Cmd.Env = append(c.Cmd.Env, envVar+"="+value)
 }
 
-func (c *Command) Kill() (killOutput []byte, err error) {
+func (c *Command) Kill() (killOutput string, err error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	if c.Process == nil {
 		// If process hasn't been started yet, nothing to kill
-		return []byte{}, nil
+		return "", nil
 	}
 	close(c.abort)
 	log.Printf("Killing process tree with parent PID %v... (%p)", c.Process.Pid, c)
 	defer log.Printf("Process tree with parent PID %v killed.", c.Process.Pid)
 	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
-	return []byte{}, syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+	return "", syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1,74 +1,8 @@
 package runtime
 
 import (
-	"bytes"
-	"errors"
-	"log"
-	"os"
-	"os/exec"
-	"strings"
-
 	"github.com/dchest/uniuri"
-	"github.com/taskcluster/shell"
 )
-
-// Runs command `command` with arguments `args`. If standard error from command
-// includes `errString` then true, is returned with no error. Otherwise false
-// is returned, with or without an error.
-func AllowError(errString string, command string, args ...string) (bool, error) {
-	log.Print("Running command: '" + strings.Join(append([]string{command}, args...), "' '") + "'")
-	cmd := exec.Command(command, args...)
-	stderrBytes, err := Error(cmd)
-	if err != nil {
-		if strings.Contains(string(stderrBytes), errString) {
-			return true, nil
-		}
-	}
-	return false, err
-}
-
-func RunCommands(allowFail bool, commands ...[]string) error {
-	var err error
-	for _, command := range commands {
-		log.Print("Running command: '" + strings.Join(command, "' '") + "'")
-		cmd := exec.Command(command[0], command[1:]...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err = cmd.Run()
-
-		if err != nil {
-			log.Printf("%v", err)
-			if !allowFail {
-				return err
-			}
-		}
-	}
-	return err
-}
-
-// Error runs the command and returns its standard error.
-func Error(c *exec.Cmd) ([]byte, error) {
-	if c.Stderr != nil {
-		return nil, errors.New("exec: Stderr already set")
-	}
-	var b bytes.Buffer
-	c.Stderr = &b
-	err := c.Run()
-	return b.Bytes(), err
-}
-
-func ProcessCommandOutput(lineEnding string, callback func(line string), prog string, options ...string) error {
-	out, err := exec.Command(prog, options...).Output()
-	if err != nil {
-		log.Printf("%v", err)
-		return err
-	}
-	for _, line := range strings.Split(string(out), lineEnding) {
-		trimmedLine := strings.Trim(line, lineEnding+" ")
-		callback(trimmedLine)
-	}
-	return nil
-}
 
 // Uses [A-Za-z0-9] characters (default set) to avoid strange escaping problems
 // that could potentially affect security. Prefixed with `pWd0_` to ensure
@@ -81,17 +15,4 @@ func ProcessCommandOutput(lineEnding string, callback func(line string), prog st
 // should not be reproducible.
 func GeneratePassword() string {
 	return "pWd0_" + uniuri.NewLen(24)
-}
-
-func CommandOutputOrPanic(command string, args ...string) string {
-	logMessage := "Running " + shell.Escape(command)
-	if len(args) > 0 {
-		logMessage += " " + shell.Escape(args...)
-	}
-	log.Print(logMessage)
-	output, err := exec.Command(command, args...).Output()
-	if err != nil {
-		panic(err)
-	}
-	return strings.TrimSpace(string(output))
 }

--- a/simple_docker.go
+++ b/simple_docker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -31,27 +30,6 @@ func PlatformTaskEnvironmentSetup(taskDirName string) (reboot bool) {
 
 func platformFeatures() []Feature {
 	return []Feature{}
-}
-
-func immediateReboot() {
-	log.Println("Immediate reboot being issued...")
-	cause := "generic-worker requested reboot"
-	log.Println(cause)
-	cmd := exec.Command("shutdown", "/r", "now", cause)
-	err := cmd.Run()
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-func immediateShutdown(cause string) {
-	log.Println("Immediate shutdown being issued...")
-	log.Println(cause)
-	cmd := exec.Command("shutdown", "now", cause)
-	err := cmd.Run()
-	if err != nil {
-		log.Fatal(err)
-	}
 }
 
 func deleteDir(path string) error {

--- a/usage_posix.go
+++ b/usage_posix.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+// +build darwin linux
 
 package main
 


### PR DESCRIPTION
See [bug 1567073](https://bugzil.la/1567073) for context.

I created a separate package (`host`) to avoid some cyclic dependencies we would have otherwise had. The idea is, this should be anything you want to do to interact with the host operating system, rather than interacting with e.g. a container/sandbox. At the moment it just contains an existing `RunCommands` function that I moved straight over from `runtime` package, and a new `RunCommand` utility method to log the command about to be run, run it, check if it fails, and if so log the combined stderr/stdout, and returns the command output and error. For convenience, it converts the output from `[]byte` to `string` since in 99% of cases that is what we want.

The other changes are just to use it, so we have a single function where we execute commands, that takes care of logging them and reporting any errors.

Note, since the function _logs the command output if the command fails_, I am no longer logging the same output from the caller. Instead the caller just typically logs the error (e.g. `exit code 1`). I chose to log the command output _inside_ the method, so that it was just in one place, rather than anything that gets an error doing exactly the same thing. However, since `error` types are typically passed back up the stack and logged at the top level where the error is handled, I intentionally am not logging the error inside `host.RunCommand` so that we don't get it logged twice unnecessarily. Often more context is added to the error message as it gets passed back up the stack, so better for _callers_ to log their own errors, rather than the `RunCommand` method that doesn't know if the `error` is significant or not.