### PR TITLE
Don't batch up the closing of http response body until function completes

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -397,7 +397,7 @@ func handleWorkerShutdown(abort func()) func() {
 				log.Printf("WARNING: error when calling AWS EC2 spot termination endpoint: %v", err)
 				continue
 			}
-			defer resp.Body.Close()
+			resp.Body.Close()
 			if resp.StatusCode == 200 {
 				abort()
 				break


### PR DESCRIPTION
I realised this was batching up the closing of the http response bodies until we got a spot termination, which was a resource leak. Since we don't process the body, we can close it immediately.