### PR TITLE
exit if remainingTasks is less than 0 (vs just 0)

### DIFF
--- a/main.go
+++ b/main.go
@@ -510,7 +510,7 @@ func RunWorker() (exitCode ExitCode) {
 				remainingTaskCountText = fmt.Sprintf(" (will exit after resolving %v more)", remainingTasks)
 			}
 			log.Printf("Resolved %v tasks in total so far%v.", tasksResolved, remainingTaskCountText)
-			if remainingTasks == 0 {
+			if remainingTasks <= 0 {
 				log.Printf("Completed all task(s) (number of tasks to run = %v)", config.NumberOfTasksToRun)
 				if deploymentIDUpdated() {
 					return NONCURRENT_DEPLOYMENT_ID


### PR DESCRIPTION
g-w should exit if remainingTasks is less than or equal to 0. 

Bitbar workers recently had an issue (due to our homegrown supersede detection) where we had a bad worker that failed ~180 tasks because g-w continued to work and didn't exit due to this. We configure g-w to exit after 1 task. We didn't use to delete the completed job counter, so remainingTasks was < 0 and g-w continued to run until it exceeded Bitbar's allowed container run time. 

related:
- https://github.com/bclary/mozilla-bitbar-docker/pull/28
- https://bugzilla.mozilla.org/show_bug.cgi?id=1375514