### PR TITLE
Bug 1592233 - calculate UID for new user under macOS multiuser

### DIFF
--- a/runtime/runtime_darwin.go
+++ b/runtime/runtime_darwin.go
@@ -26,6 +26,8 @@ func (user *OSUser) CreateNew(okIfExists bool) (err error) {
 		fullname="${0}"
 		password="${1}"
 		echo "Creating user '${username}' with home directory '${homedir}' and password '${password}'..."
+		maxid=$(dscl . -list '/Users' 'UniqueID' | awk '{print $2}' | sort -ug | tail -1)
+		uid=$((maxid+1))
 		/usr/bin/sudo dscl . -create "/Users/${username}"
 		/usr/bin/sudo dscl . -create "/Users/${username}" 'UserShell' '/bin/bash'
 		/usr/bin/sudo dscl . -create "/Users/${username}" 'RealName' "${fullname}"

--- a/runtime/runtime_darwin.go
+++ b/runtime/runtime_darwin.go
@@ -26,7 +26,7 @@ func (user *OSUser) CreateNew(okIfExists bool) (err error) {
 		fullname="${0}"
 		password="${1}"
 		echo "Creating user '${username}' with home directory '${homedir}' and password '${password}'..."
-		maxid=$(dscl . -list '/Users' 'UniqueID' | awk '{print $2}' | sort -ug | tail -1)
+		maxid=$(dscl . -list '/Users' 'UniqueID' | awk '{print $2}' | sort -un | tail -1)
 		uid=$((maxid+1))
 		/usr/bin/sudo dscl . -create "/Users/${username}"
 		/usr/bin/sudo dscl . -create "/Users/${username}" 'UserShell' '/bin/bash'


### PR DESCRIPTION
Whoops!

See [bug 1592233](https://bugzil.la/1592233) for context. These two lines [used to exist](https://github.com/taskcluster/generic-worker/commit/814aa9e8afee3e925b1295eeda12841da8754404#diff-db028d655af10079249eb4d4a2b5120cL29-L30) but got deleted because I thought they were no longer needed, but it seems they were.

Since I hadn't upgraded any mac workers, I hadn't spotted that this was broken, and unfortunately the unit and integration tests didn't catch it.