### PR TITLE
Bug 1593483 part 2

### DIFF
--- a/aws_broken_on_docker_test.go
+++ b/aws_broken_on_docker_test.go
@@ -10,7 +10,9 @@ func TestWorkerShutdown(t *testing.T) {
 	m := &MockAWSProvisionedEnvironment{
 		Terminating: true,
 	}
-	defer m.ExpectNoError(t)()
+	teardown, err := m.Setup(t)
+	defer teardown()
+	m.ExpectNoError(t, err)
 	payload := GenericWorkerPayload{
 		Command:    sleep(20),
 		MaxRunTime: 15,

--- a/aws_helper_test.go
+++ b/aws_helper_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/taskcluster/generic-worker/gwconfig"
 	"github.com/taskcluster/taskcluster-client-go/tcpurgecache"
 	"github.com/taskcluster/taskcluster-client-go/tcqueue"
 )
@@ -262,7 +263,10 @@ func (m *MockAWSProvisionedEnvironment) Setup(t *testing.T) (teardown func(), er
 		s.ListenAndServe()
 		t.Log("HTTP server for mock Provisioner and EC2 metadata endpoints stopped")
 	}()
-	config, err = loadConfig(filepath.Join(testdataDir, t.Name(), "generic-worker.config"), true, false)
+	configFile := &gwconfig.File{
+		Path: filepath.Join(testdataDir, t.Name(), "generic-worker.config"),
+	}
+	configProvider, err = loadConfig(configFile, true, false)
 	return func() {
 		td()
 		err := s.Shutdown(context.Background())
@@ -277,20 +281,14 @@ func (m *MockAWSProvisionedEnvironment) Setup(t *testing.T) (teardown func(), er
 	}, err
 }
 
-func (m *MockAWSProvisionedEnvironment) ExpectError(t *testing.T, errorText string) (teardown func()) {
-	var err error
-	teardown, err = m.Setup(t)
+func (m *MockAWSProvisionedEnvironment) ExpectError(t *testing.T, errorText string, err error) {
 	if err == nil || !strings.Contains(err.Error(), errorText) {
 		t.Fatalf("Was expecting error to include %q but got: %v", errorText, err)
 	}
-	return
 }
 
-func (m *MockAWSProvisionedEnvironment) ExpectNoError(t *testing.T) (teardown func()) {
-	var err error
-	teardown, err = m.Setup(t)
+func (m *MockAWSProvisionedEnvironment) ExpectNoError(t *testing.T, err error) {
 	if err != nil {
 		t.Fatalf("Was expecting no error but got: %v", err)
 	}
-	return
 }

--- a/awsprovider.go
+++ b/awsprovider.go
@@ -8,13 +8,25 @@ import (
 	"github.com/taskcluster/taskcluster-client-go/tcworkermanager"
 )
 
-func updateConfigAWSProvider(c *gwconfig.Config, awsMetadata map[string][]byte, userData *WorkerManagerUserData) error {
+type AWSProvider struct {
+	UserData *WorkerManagerUserData
+}
 
+func (a *AWSProvider) NewestDeploymentID() (string, error) {
+	return WMDeploymentID()
+}
+
+func (a *AWSProvider) UpdateConfig(c *gwconfig.Config) error {
+
+	awsMetadata, err := AWSUpdateConfig(c)
+	if err != nil {
+		return err
+	}
 	providerType := &tcworkermanager.AwsProviderType{
 		// Document must be a string, not an object
 		Document:  json.RawMessage(fmt.Sprintf(`%q`, string(awsMetadata["document"]))),
 		Signature: string(awsMetadata["signature"]),
 	}
 
-	return userData.updateConfig(c, providerType)
+	return a.UserData.UpdateConfig(c, providerType)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -11,9 +11,11 @@ import (
 )
 
 func TestMissingIPConfig(t *testing.T) {
-	file := filepath.Join("testdata", "config", "noip.json")
+	file := &gwconfig.File{
+		Path: filepath.Join("testdata", "config", "noip.json"),
+	}
 	const setting = "publicIP"
-	config, err := loadConfig(file, false, false)
+	_, err := loadConfig(file, false, false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -32,10 +34,12 @@ func TestMissingIPConfig(t *testing.T) {
 }
 
 func TestValidConfig(t *testing.T) {
-	file := filepath.Join("testdata", "config", "valid.json")
+	file := &gwconfig.File{
+		Path: filepath.Join("testdata", "config", "valid.json"),
+	}
 	const ipaddr = "2.1.2.1"
 	const workerType = "some-worker-type"
-	config, err := loadConfig(file, false, false)
+	_, err := loadConfig(file, false, false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -52,7 +56,9 @@ func TestValidConfig(t *testing.T) {
 }
 
 func TestInvalidIPConfig(t *testing.T) {
-	file := filepath.Join("testdata", "config", "invalid-ip.json")
+	file := &gwconfig.File{
+		Path: filepath.Join("testdata", "config", "invalid-ip.json"),
+	}
 	_, err := loadConfig(file, false, false)
 	if err == nil {
 		t.Fatal("Was expecting to get an error back due to an invalid IP address, but didn't get one!")
@@ -64,7 +70,9 @@ func TestInvalidIPConfig(t *testing.T) {
 }
 
 func TestInvalidJsonConfig(t *testing.T) {
-	file := filepath.Join("testdata", "config", "invalid-json.json")
+	file := &gwconfig.File{
+		Path: filepath.Join("testdata", "config", "invalid-json.json"),
+	}
 	_, err := loadConfig(file, false, false)
 	if err == nil {
 		t.Fatal("Was expecting to get an error back due to an invalid JSON config, but didn't get one!")
@@ -76,7 +84,9 @@ func TestInvalidJsonConfig(t *testing.T) {
 }
 
 func TestMissingConfigFile(t *testing.T) {
-	file := filepath.Join("testdata", "config", "non-existent-json.json")
+	file := &gwconfig.File{
+		Path: filepath.Join("testdata", "config", "non-existent-json.json"),
+	}
 	_, err := loadConfig(file, false, false)
 	if err == nil {
 		t.Fatal("Was expecting an error when loading non existent config file without --configure-for-{aws,gcp} set")
@@ -87,8 +97,10 @@ func TestMissingConfigFile(t *testing.T) {
 }
 
 func TestWorkerTypeMetadata(t *testing.T) {
-	file := filepath.Join("testdata", "config", "worker-type-metadata.json")
-	config, err := loadConfig(file, false, false)
+	file := &gwconfig.File{
+		Path: filepath.Join("testdata", "config", "worker-type-metadata.json"),
+	}
+	_, err := loadConfig(file, false, false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -111,7 +123,9 @@ func TestWorkerTypeMetadata(t *testing.T) {
 }
 
 func TestBoolAsString(t *testing.T) {
-	file := filepath.Join("testdata", "config", "bool-as-string.json")
+	file := &gwconfig.File{
+		Path: filepath.Join("testdata", "config", "bool-as-string.json"),
+	}
 	_, err := loadConfig(file, false, false)
 	if err == nil {
 		t.Fatal("Was expecting to get an error back due to a bool being specified as a string, but didn't get one!")

--- a/gcp.go
+++ b/gcp.go
@@ -20,6 +20,15 @@ var (
 	GCPMetadataBaseURL = "http://metadata.google.internal/computeMetadata/v1"
 )
 
+type GCPConfigProvider struct {
+}
+
+type GCPWorkerLocation struct {
+	Cloud  string `json:"cloud"`
+	Region string `json:"region"`
+	Zone   string `json:"zone"`
+}
+
 func queryGCPMetaData(client *http.Client, path string) ([]byte, error) {
 	req, err := http.NewRequest("GET", GCPMetadataBaseURL+path, nil)
 
@@ -37,13 +46,7 @@ func queryGCPMetaData(client *http.Client, path string) ([]byte, error) {
 	return ioutil.ReadAll(resp.Body)
 }
 
-type GCPWorkerLocation struct {
-	Cloud  string `json:"cloud"`
-	Region string `json:"region"`
-	Zone   string `json:"zone"`
-}
-
-func updateConfigWithGCPSettings(c *gwconfig.Config) error {
+func (g *GCPConfigProvider) UpdateConfig(c *gwconfig.Config) error {
 	log.Print("Querying GCP Metadata to get default worker type config settings...")
 
 	client := &http.Client{}
@@ -100,7 +103,7 @@ func updateConfigWithGCPSettings(c *gwconfig.Config) error {
 		Token: string(identity),
 	}
 
-	err = userData.updateConfig(c, providerType)
+	err = userData.UpdateConfig(c, providerType)
 	if err != nil {
 		return err
 	}
@@ -125,4 +128,8 @@ func updateConfigWithGCPSettings(c *gwconfig.Config) error {
 		c.WorkerLocation = string(workerLocationJSON)
 	}
 	return nil
+}
+
+func (g *GCPConfigProvider) NewestDeploymentID() (string, error) {
+	return WMDeploymentID()
 }

--- a/gcp_helper_test.go
+++ b/gcp_helper_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/taskcluster/generic-worker/gwconfig"
 	"github.com/taskcluster/taskcluster-client-go/tcworkermanager"
 )
 
@@ -122,7 +123,10 @@ func (m *MockGCPProvisionedEnvironment) Setup(t *testing.T) func() {
 		t.Log("HTTP server for mock Provisioner and GCP metadata endpoints stopped")
 	}()
 	var err error
-	config, err = loadConfig(filepath.Join(testdataDir, t.Name(), "generic-worker.config"), false, true)
+	configFile := &gwconfig.File{
+		Path: filepath.Join(testdataDir, t.Name(), "generic-worker.config"),
+	}
+	configProvider, err = loadConfig(configFile, false, true)
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}

--- a/gwconfig/provider.go
+++ b/gwconfig/provider.go
@@ -1,0 +1,14 @@
+package gwconfig
+
+// gwconfig.Provider is an interface for configuring generic-worker.
+// Implementors include AWSProvisioner, AWSProvider, GCPConfigProvider, and
+// gwconfig.File for configuring generic-worker from a local file.
+type Provider interface {
+	// NewestDeploymentID fetches the latest/newest/most-recent deployment ID.
+	// Depending on the provider, this may make a network request to retrieve
+	// data from a taskcluster entity (such as a worker pool definition) or may
+	// just look at the local generic-worker config file. See generic-worker
+	// help text for information about the deploymentId property.
+	NewestDeploymentID() (string, error)
+	UpdateConfig(c *Config) error
+}

--- a/helper_test.go
+++ b/helper_test.go
@@ -170,11 +170,19 @@ func setup(t *testing.T) (teardown func()) {
 			},
 		},
 	}
-	newestDeploymentID = func() (string, error) {
-		return config.DeploymentID, nil
-	}
+	configProvider = &TestProvider{}
 	setConfigRunTasksAsCurrentUser()
 	return teardown
+}
+
+type TestProvider struct{}
+
+func (tp *TestProvider) NewestDeploymentID() (string, error) {
+	return config.DeploymentID, nil
+}
+
+func (tp *TestProvider) UpdateConfig(c *gwconfig.Config) error {
+	return nil
 }
 
 // testWorkerType returns a fake workerType identifier that conforms to

--- a/worker_types/gwci-linux-beta/bootstrap.sh
+++ b/worker_types/gwci-linux-beta/bootstrap.sh
@@ -6,7 +6,7 @@ exec &> /var/log/bootstrap.log
 # Versions ###########################
 LIVELOG_VERSION='v1.1.0'
 TASKCLUSTER_PROXY_VERSION='v5.1.0'
-GENERIC_WORKER_BRANCH='bug1588834'
+GENERIC_WORKER_BRANCH='bug1593483-part2'
 ######################################
 
 function retry {


### PR DESCRIPTION
See [bug 1593483](https://bugzil.la/1593483) for additional context.

I think this should do it. It is pretty tricky to test.

The problem we had before was that if config file was found on the file system, we avoided the config negotiation with AWSProvisioner/WorkerManager and used the config file we had persisted. However, the function to check for a new `deploymentId` was therefore not updated, so the check for a new `deploymentId` was using the default function which just checked the local generic-worker config file, rather than talking to AWSProvisioner/WorkerManager.

The way I've solved this turned out to be a bit of a rewriting, so that we have a `gwconfig.Provider` interface that has a method for updating generic-worker config, and for fetching the latest deployment ID.

